### PR TITLE
Release asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ The supported options are:
 - `--release-asset` (**Optional**): The name of a release asset--that is, a binary uploaded to a [GitHub
   Release](https://help.github.com/articles/creating-releases/)--to download. This option can be specified more than
   once. It only works with the `--tag` option.
-- `--github-oauth-token` (**Optiona**): A [GitHub Personal Access
+- `--github-oauth-token` (**Optional**): A [GitHub Personal Access
   Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/). Required if you're
-  downloading from private GitHub repos.
+  downloading from private GitHub repos. **NOTE:** fetch will also look for this token using the `GITHUB_OAUTH_TOKEN`
+  environment variable, which we recommend using instead of the command line option to ensure the token doesn't get
+  saved in bash history.
 
 The supported arguments are:
 
@@ -92,10 +94,11 @@ fetch \
 Download all files from a private GitHub repo using the GitHUb oAuth Token `123`. Get the release whose tag is exactly `0.1.5`, and save the files to `/tmp`:
 
 ```
+GITHUB_OAUTH_TOKEN=123
+
 fetch \
 --repo="https://github.com/gruntwork-io/script-modules" \
 --tag="0.1.5" \
---github-oauth-token="123" \
 /tmp
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # fetch
 
-fetch downloads all or a subset of files or folders from a specific git commit, branch or tag of a GitHub repo.
+fetch downloads all or a subset of files or folders from a specific git commit, branch, tag, or release of a GitHub
+repo.
 
 #### Features
 
 - Download from a specific git commit SHA.
 - Download from a specific git tag.
 - Download from a specific git branch.
+- Download a binary asset from a specific release.
 - Download from public repos.
 - Download from private repos by specifying a [GitHub Personal Access Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
 - Download a single file, a subset of files, or all files from the repo.
@@ -15,40 +17,50 @@ fetch downloads all or a subset of files or folders from a specific git commit, 
 ## Motivation
 
 [Gruntwork](http://gruntwork.io) helps software teams get up and running on AWS with DevOps best practices and world-class 
-infrastructure in about 2 weeks. Sometimes we publish scripts that clients use in their infrastructure, and we want clients
-to auto-download the latest non-breaking version of a script when we publish updates. In addition, for security reasons,
-we wish to verify the integrity of the git commit being downloaded.
+infrastructure in about 2 weeks. Sometimes we publish scripts and binaries that clients use in their infrastructure,
+and we want clients to auto-download the latest non-breaking version of that script or binary when we publish updates.
+In addition, for security reasons, we wish to verify the integrity of the git commit being downloaded.
 
 ## Installation
 
-Download the binary from the [GitHub Releases](https://github.com/gruntwork-io/fetch/releases) tab. 
+Download the fetch binary from the [GitHub Releases](https://github.com/gruntwork-io/fetch/releases) tab.
 
 ## Assumptions
 
-fetch assumes that a repo's tags are in the format `vX.Y.Z` or `X.Y.Z` to support Semantic Versioning parsing. Repos that
-use git tags not in this format cannot be used with fetch.
+fetch assumes that a repo's tags are in the format `vX.Y.Z` or `X.Y.Z` to support Semantic Versioning parsing. Repos
+that use git tags not in this format cannot currently be used with fetch.
 
 ## Usage
 
 #### General Usage
 
 ```
-fetch --repo=<github-repo-url> --tag=<version-constraint> [<repo-download-filter>] <local-download-path>
+fetch [OPTIONS] <local-download-path>
 ```
 
-- `<repo-download-filter>` 
-  **Optional**.
-  If blank, all files in the repo will be downloaded. Otherwise, only files located in the given path
-  will be downloaded. 
-  - Example: `/` Download all files in the repo
-  - Example: `/folder` Download only files in the `/folder` path and below from the repo
-- `<local-download-path>`
-  **Required**.
-  The local path where all files should be downloaded.
-  - Example: `/tmp` Download all files to `/tmp`
+The supported options are:
 
-Run `fetch --help` to see more information about the flags, some of which are required. See [Tag Constraint Expressions](#tag-constraint-expressions)
-for examples of tag constraints you can use.
+- `--repo` (**Required**): The fully qualified URL of the GitHub repo to download from (e.g. https://github.com/foo/bar).
+- `--tag` (**Optional**): The git tag to download. Can be a specific tag or a [Tag Constraint
+  Expression](#tag-constraint-expressions).
+- `--branch` (**Optional**): The git branch from which to download; the latest commit in the branch will be used. If
+  specified, will override `--tag`.
+- `--commit` (**Optional**): The SHA of a git commit to download. If specified, will override `--branch` and `--tag`.
+- `--source-path` (**Optional**): The source path to download from the repo (e.g. `--source-path=/folder` will download
+  the `/folder` path and all files below it). By default, all files are downloaded from the repo unless `--source-path`
+  or `--release-asset` is specified. This option can be specified more than once.
+- `--release-asset` (**Optional**): The name of a release asset--that is, a binary uploaded to a [GitHub
+  Release](https://help.github.com/articles/creating-releases/)--to download. This option can be specified more than
+  once. It only works with the `--tag` option.
+- `--github-oauth-token` (**Optiona**): A [GitHub Personal Access
+  Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/). Required if you're
+  downloading from private GitHub repos.
+
+The supported arguments are:
+
+- `<local-download-path>` (**Required**): The local path where all files should be downloaded (e.g. `/tmp`).
+
+Run `fetch --help` to see more information about the flags.
 
 #### Usage Example 1
 
@@ -58,7 +70,7 @@ Download `/modules/foo/bar.sh` from a GitHub release where the tag is the latest
 fetch \
 --repo="https://github.com/gruntwork-io/script-modules" \
 --tag="~>0.1.5" \
-/modules/foo/bar.sh \
+--source-path="/modules/foo/bar.sh" \
 /tmp/bar
 ```
 
@@ -70,7 +82,7 @@ Download all files in `/modules/foo` from a GitHub release where the tag is exac
 fetch \
 --repo="https://github.com/gruntwork-io/script-modules" \
 --tag="0.1.5" \
-/modules/foo \
+--source-path="/modules/foo" \
 /tmp
 
 ```
@@ -111,6 +123,17 @@ fetch \
 /tmp/josh1
 
 ```
+
+#### Usage Example 6
+
+Download the release asset `foo.exe` from a GitHub release where the tag is exactly `0.1.5`, and save it to `/tmp`:
+
+```
+fetch \
+--repo="https://github.com/gruntwork-io/script-modules" \
+--tag="0.1.5" \
+--release-asset="foo.exe" \
+/tmp
 
 
 #### Tag Constraint Expressions

--- a/fetch_error.go
+++ b/fetch_error.go
@@ -23,6 +23,9 @@ func newError(errorCode int, details string) *FetchError {
 }
 
 func wrapError(err error) *FetchError {
+	if err == nil {
+		return nil
+	}
 	return &FetchError{
 		errorCode: -1,
 		details: err.Error(),


### PR DESCRIPTION
This PR allows fetch to download not only source files from GitHub repos, but also binary files from GitHub releases. It’s easy to download a release asset from a public repo, as you can just `wget` the URL, but for private repos, it’s a confusing, painful, multi-step process that involves making several API calls. There is an [SO thread about it](http://stackoverflow.com/a/35280061/483528) which would probably love to hear that `fetch` makes this an easy one-step process.

As part of this PR, I’ve also made a few other tweaks:

1. Added support to fetch to read the GITHUB_OAUTH_TOKEN from an env var, which is much safer than as a command line option.
1. Instead of a filter passed as a command-line arg, you can now specify one or more paths to download from the source code using the `--source-path` option.
1. Similarly, you can download one or more release assets using the `--release-asset` option.