### PR TITLE
added additional constraint check for ~> matching

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -1,85 +1,85 @@
 package main
 
 import (
-  "sort"
-  "strings"
-  "errors"
-  "github.com/hashicorp/go-version"
+  	"sort"
+  	"strings"
+  	"errors"
+  	"github.com/hashicorp/go-version"
 )
 
 func isTagConstraintSpecificTag(tagConstraint string) (bool, string) {
-  if len(tagConstraint) > 0 {
-    switch tagConstraint[0] {
-    // Check for a tagConstraint '='
-    case '=':
-      return true, strings.TrimSpace(tagConstraint[1:])
+  	if len(tagConstraint) > 0 {
+    		switch tagConstraint[0] {
+    		// Check for a tagConstraint '='
+    		case '=':
+      			return true, strings.TrimSpace(tagConstraint[1:])
 
-    // Check for a tagConstraint without constraint specifier
-    // Neither of '!=', '>', '>=', '<', '<=', '~>' is prefixed before tag
-    case '>', '<', '!', '~':
-      return false, tagConstraint
+    		// Check for a tagConstraint without constraint specifier
+    		// Neither of '!=', '>', '>=', '<', '<=', '~>' is prefixed before tag
+    		case '>', '<', '!', '~':
+      			return false, tagConstraint
 
-    default:
-      return true, strings.TrimSpace(tagConstraint)
-    }
-  }
-  return false, tagConstraint
+    		default:
+      			return true, strings.TrimSpace(tagConstraint)
+    		}
+  	}
+  	return false, tagConstraint
 }
 
 func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *FetchError) {
-  var latestTag string
+  	var latestTag string
 
-  if len(tags) == 0 {
-    return latestTag, nil
-  }
+  	if len(tags) == 0 {
+    		return latestTag, nil
+  	}
 
-  // Sort all tags
-  // Our use of the library go-version means that each tag will each be represented as a *version.Version
-  versions := make([]*version.Version, len(tags))
-  for i, tag := range tags {
-    v, err := version.NewVersion(tag)
-    if err != nil {
-      return latestTag, wrapError(err)
-    }
+  	// Sort all tags
+  	// Our use of the library go-version means that each tag will each be represented as a *version.Version
+  	versions := make([]*version.Version, len(tags))
+  	for i, tag := range tags {
+    		v, err := version.NewVersion(tag)
+    		if err != nil {
+      			return latestTag, wrapError(err)
+    		}
 
-    versions[i] = v
-  }
-  sort.Sort(version.Collection(versions))
+    		versions[i] = v
+  	}
+  	sort.Sort(version.Collection(versions))
 
-  // If the tag constraint is empty, set it to the latest tag
-  if tagConstraint == "" {
-    tagConstraint = versions[len(versions)-1].String()
-  }
+  	// If the tag constraint is empty, set it to the latest tag
+  	if tagConstraint == "" {
+    		tagConstraint = versions[len(versions)-1].String()
+  	}
 
-  // Find the latest version that matches the given tag constraint
-  constraints, err := version.NewConstraint(tagConstraint)
-  if err != nil {
-    // Explicitly check for a malformed tag value so we can return a nice error to the user
-    if strings.Contains(err.Error(), "Malformed constraint") {
-      return latestTag, newError(INVALID_TAG_CONSTRAINT_EXPRESSION, err.Error())
-    } else {
-      return latestTag, wrapError(err)
-    }
-  }
+  	// Find the latest version that matches the given tag constraint
+  	constraints, err := version.NewConstraint(tagConstraint)
+  	if err != nil {
+    		// Explicitly check for a malformed tag value so we can return a nice error to the user
+    		if strings.Contains(err.Error(), "Malformed constraint") {
+      			return latestTag, newError(INVALID_TAG_CONSTRAINT_EXPRESSION, err.Error())
+    		} else {
+      			return latestTag, wrapError(err)
+    		}
+  	}
 
-  latestAcceptableVersion := versions[0]
-  for _, version := range versions {
-    if constraints.Check(version) && version.GreaterThan(latestAcceptableVersion) {
-      latestAcceptableVersion = version
-    }
-  }
+  	latestAcceptableVersion := versions[0]
+  	for _, version := range versions {
+    		if constraints.Check(version) && version.GreaterThan(latestAcceptableVersion) {
+      			latestAcceptableVersion = version
+    		}
+  	}
 
     // check contstraint against only the latest acceptable version
-  if !constraints.Check(latestAcceptableVersion) {
-      return latestTag, wrapError(errors.New("Tag does not exist"))
-  }
+  	if !constraints.Check(latestAcceptableVersion) {
+      	return latestTag, wrapError(errors.New("Tag does not exist"))
+  	}
 
-  // The tag name may have started with a "v". If so, re-apply that string now
-  for _, originalTagName := range tags {
-    if strings.Contains(originalTagName, latestAcceptableVersion.String()) {
-      latestTag = originalTagName
-    }
-  }
+  	// The tag name may have started with a "v". If so, re-apply that string now
+  	for _, originalTagName := range tags {
+    		if strings.Contains(originalTagName, latestAcceptableVersion.String()) {
+      			latestTag = originalTagName
+    		}
+  	}
 
-  return latestTag, nil
+  	return latestTag, nil
 }

--- a/tag.go
+++ b/tag.go
@@ -69,8 +69,8 @@ func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *Fetch
     		}
   	}
 
-		// check contstraint against only the latest acceptable version
-  	if !constraints.Check(latestAcceptableVersion) {
+		// check constraint against only the latest acceptable version
+		if !constraints.Check(latestAcceptableVersion) {
       	return latestTag, wrapError(errors.New("Tag does not exist"))
   	}
 

--- a/tag.go
+++ b/tag.go
@@ -3,7 +3,7 @@ package main
 import (
 	"sort"
 	"strings"
-
+    "errors"
 	"github.com/hashicorp/go-version"
 )
 
@@ -69,9 +69,9 @@ func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *Fetch
 		}
 	}
 
-    // check contstraint against only the latest acceptable version, not all versions like the above for loop
+    // check contstraint against only the latest acceptable version
     if !constraints.Check(latestAcceptableVersion) {
-        return latestTag, nil
+        return latestTag, wrapError(errors.New("Tag does not exist"))
     }
 
 	// The tag name may have started with a "v". If so, re-apply that string now

--- a/tag.go
+++ b/tag.go
@@ -69,6 +69,11 @@ func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *Fetch
 		}
 	}
 
+    // check contstraint against only the latest acceptable version, not all versions like the above for loop
+    if !constraints.Check(latestAcceptableVersion) {
+        return latestTag, nil
+    }
+
 	// The tag name may have started with a "v". If so, re-apply that string now
 	for _, originalTagName := range tags {
 		if strings.Contains(originalTagName, latestAcceptableVersion.String()) {

--- a/tag.go
+++ b/tag.go
@@ -69,7 +69,7 @@ func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *Fetch
     		}
   	}
 
-    // check contstraint against only the latest acceptable version
+		// check contstraint against only the latest acceptable version
   	if !constraints.Check(latestAcceptableVersion) {
       	return latestTag, wrapError(errors.New("Tag does not exist"))
   	}

--- a/tag.go
+++ b/tag.go
@@ -1,85 +1,85 @@
 package main
 
 import (
-	"sort"
-	"strings"
+  "sort"
+  "strings"
   "errors"
-	"github.com/hashicorp/go-version"
+  "github.com/hashicorp/go-version"
 )
 
 func isTagConstraintSpecificTag(tagConstraint string) (bool, string) {
-	if len(tagConstraint) > 0 {
-		switch tagConstraint[0] {
-		// Check for a tagConstraint '='
-		case '=':
-			return true, strings.TrimSpace(tagConstraint[1:])
+  if len(tagConstraint) > 0 {
+    switch tagConstraint[0] {
+    // Check for a tagConstraint '='
+    case '=':
+      return true, strings.TrimSpace(tagConstraint[1:])
 
-		// Check for a tagConstraint without constraint specifier
-		// Neither of '!=', '>', '>=', '<', '<=', '~>' is prefixed before tag
-		case '>', '<', '!', '~':
-			return false, tagConstraint
+    // Check for a tagConstraint without constraint specifier
+    // Neither of '!=', '>', '>=', '<', '<=', '~>' is prefixed before tag
+    case '>', '<', '!', '~':
+      return false, tagConstraint
 
-		default:
-			return true, strings.TrimSpace(tagConstraint)
-		}
-	}
-	return false, tagConstraint
+    default:
+      return true, strings.TrimSpace(tagConstraint)
+    }
+  }
+  return false, tagConstraint
 }
 
 func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *FetchError) {
-	var latestTag string
+  var latestTag string
 
-	if len(tags) == 0 {
-		return latestTag, nil
-	}
+  if len(tags) == 0 {
+    return latestTag, nil
+  }
 
-	// Sort all tags
-	// Our use of the library go-version means that each tag will each be represented as a *version.Version
-	versions := make([]*version.Version, len(tags))
-	for i, tag := range tags {
-		v, err := version.NewVersion(tag)
-		if err != nil {
-			return latestTag, wrapError(err)
-		}
+  // Sort all tags
+  // Our use of the library go-version means that each tag will each be represented as a *version.Version
+  versions := make([]*version.Version, len(tags))
+  for i, tag := range tags {
+    v, err := version.NewVersion(tag)
+    if err != nil {
+      return latestTag, wrapError(err)
+    }
 
-		versions[i] = v
-	}
-	sort.Sort(version.Collection(versions))
+    versions[i] = v
+  }
+  sort.Sort(version.Collection(versions))
 
-	// If the tag constraint is empty, set it to the latest tag
-	if tagConstraint == "" {
-		tagConstraint = versions[len(versions)-1].String()
-	}
+  // If the tag constraint is empty, set it to the latest tag
+  if tagConstraint == "" {
+    tagConstraint = versions[len(versions)-1].String()
+  }
 
-	// Find the latest version that matches the given tag constraint
-	constraints, err := version.NewConstraint(tagConstraint)
-	if err != nil {
-		// Explicitly check for a malformed tag value so we can return a nice error to the user
-		if strings.Contains(err.Error(), "Malformed constraint") {
-			return latestTag, newError(INVALID_TAG_CONSTRAINT_EXPRESSION, err.Error())
-		} else {
-			return latestTag, wrapError(err)
-		}
-	}
+  // Find the latest version that matches the given tag constraint
+  constraints, err := version.NewConstraint(tagConstraint)
+  if err != nil {
+    // Explicitly check for a malformed tag value so we can return a nice error to the user
+    if strings.Contains(err.Error(), "Malformed constraint") {
+      return latestTag, newError(INVALID_TAG_CONSTRAINT_EXPRESSION, err.Error())
+    } else {
+      return latestTag, wrapError(err)
+    }
+  }
 
-	latestAcceptableVersion := versions[0]
-	for _, version := range versions {
-		if constraints.Check(version) && version.GreaterThan(latestAcceptableVersion) {
-			latestAcceptableVersion = version
-		}
-	}
+  latestAcceptableVersion := versions[0]
+  for _, version := range versions {
+    if constraints.Check(version) && version.GreaterThan(latestAcceptableVersion) {
+      latestAcceptableVersion = version
+    }
+  }
 
     // check contstraint against only the latest acceptable version
   if !constraints.Check(latestAcceptableVersion) {
       return latestTag, wrapError(errors.New("Tag does not exist"))
   }
 
-	// The tag name may have started with a "v". If so, re-apply that string now
-	for _, originalTagName := range tags {
-		if strings.Contains(originalTagName, latestAcceptableVersion.String()) {
-			latestTag = originalTagName
-		}
-	}
+  // The tag name may have started with a "v". If so, re-apply that string now
+  for _, originalTagName := range tags {
+    if strings.Contains(originalTagName, latestAcceptableVersion.String()) {
+      latestTag = originalTagName
+    }
+  }
 
-	return latestTag, nil
+  return latestTag, nil
 }

--- a/tag.go
+++ b/tag.go
@@ -3,7 +3,7 @@ package main
 import (
 	"sort"
 	"strings"
-    "errors"
+  "errors"
 	"github.com/hashicorp/go-version"
 )
 
@@ -70,9 +70,9 @@ func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *Fetch
 	}
 
     // check contstraint against only the latest acceptable version
-    if !constraints.Check(latestAcceptableVersion) {
-        return latestTag, wrapError(errors.New("Tag does not exist"))
-    }
+  if !constraints.Check(latestAcceptableVersion) {
+      return latestTag, wrapError(errors.New("Tag does not exist"))
+  }
 
 	// The tag name may have started with a "v". If so, re-apply that string now
 	for _, originalTagName := range tags {

--- a/tag_test.go
+++ b/tag_test.go
@@ -31,7 +31,7 @@ func TestGetLatestAcceptableTag(t *testing.T) {
 
 	for _, tc := range cases {
 		tag, err := getLatestAcceptableTag(tc.tagConstraint, tc.tags)
-		if err != nil && err.details != "Tag does not exist" {
+		if err != nil {
 			t.Fatalf("Failed on call to getLatestAcceptableTag: %s", err.details)
 		}
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -31,7 +31,7 @@ func TestGetLatestAcceptableTag(t *testing.T) {
 
 	for _, tc := range cases {
 		tag, err := getLatestAcceptableTag(tc.tagConstraint, tc.tags)
-		if err != nil {
+		if err != nil && err.details != "Tag does not exist" {
 			t.Fatalf("Failed on call to getLatestAcceptableTag: %s", err.details)
 		}
 
@@ -119,4 +119,22 @@ func TestGetLatestAcceptableTagOnMalformedConstraint(t *testing.T) {
 			t.Fatalf("Expected malformed constraint error, but received nothing.")
 		}
 	}
+}
+
+func TestGetLatestAcceptableTagNoSuchTag (t *testing.T) {
+    t.Parallel()
+
+    cases := []struct {
+        tagConstraint string
+        tags []string
+    }{
+        {"~> 0.0.4", []string{"0.0.1", "0.0.2", "0.0.3"} },
+    }
+
+    for _, tc := range cases{
+        _, err := getLatestAcceptableTag(tc.tagConstraint, tc.tags)
+        if err == nil {
+            t.Fatalf("Expected Tag does not exist error, but received nothing")
+        }
+    }
 }


### PR DESCRIPTION
this should fix  issue #6 where the `~>` operator finds an acceptable tag on what should be an unavailable tag. 