### PR TITLE
added fix and test for issue #6

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -3,7 +3,7 @@ package main
 import (
 	"sort"
 	"strings"
-
+	"errors"
 	"github.com/hashicorp/go-version"
 )
 
@@ -67,6 +67,11 @@ func getLatestAcceptableTag(tagConstraint string, tags []string) (string, *Fetch
 		if constraints.Check(version) && version.GreaterThan(latestAcceptableVersion) {
 			latestAcceptableVersion = version
 		}
+	}
+
+	// check constraint against latest acceptable version
+	if !constraints.Check(latestAcceptableVersion) {
+		return latestTag, wrapError(errors.New("Tag does not exist"))
 	}
 
 	// The tag name may have started with a "v". If so, re-apply that string now

--- a/tag_test.go
+++ b/tag_test.go
@@ -120,3 +120,21 @@ func TestGetLatestAcceptableTagOnMalformedConstraint(t *testing.T) {
 		}
 	}
 }
+
+func TestGetLatestAcceptableTagNoSuchTag(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		tagConstraint string
+		tags []string
+	}{
+		{"~> 0.0.4", []string{"0.0.1", "0.0.2", "0.0.3"}},
+		{"> 0.0.4", []string{"0.0.1", "0.0.2", "0.0.3"}},
+	}
+
+	for _, tc := range cases {
+		_, err := getLatestAcceptableTag(tc.tagConstraint, tc.tags)
+		if err == nil {
+			t.Fatalf("Expected 'Tag does not exist' but received nothing")
+		}
+	}
+}


### PR DESCRIPTION
OK @brikis98 this should do it. Apologies for the changes and clutter regarding the indents ... :/

**Test output before change:**
```
--- FAIL: TestGetLatestAcceptableTagNoSuchTag (0.00s)
        tag_test.go:137: Expected 'Tag does not exist' but received nothing
FAIL
coverage: 49.4% of statements
exit status 1
FAIL    _/home/src      8.597s
```

**Test output after change:**
```
PASS
coverage: 50.2% of statements
ok      _/home/src      8.482s
```

Let me know if there is anything else needed!