### PR TITLE
Add support for "resolving" symlinks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The supported options are:
   downloading from private GitHub repos. **NOTE:** fetch will also look for this token using the `GITHUB_OAUTH_TOKEN`
   environment variable, which we recommend using instead of the command line option to ensure the token doesn't get
   saved in bash history.
+- `--resolve-symlinks`: If set to true, Fetch will attempt to resolve any symlinks in the repo by replacing the symlinks
+  with the contents of the targets they point to.
 
 The supported arguments are:
 
@@ -158,6 +160,5 @@ This code is released under the MIT License. See [LICENSE.txt](/LICENSE.txt).
 
 ## TODO
 
-- Introduce code verification using something like GPG signatures or published checksums
 - Explicitly test for exotic repo and org names
 - Apply stricter parsing for repo-filter command-line arg

--- a/file.go
+++ b/file.go
@@ -177,7 +177,8 @@ func writeFileAsSymLink(f *zip.File, path string) error {
 func evalSymLinkAndCopyFiles(f *zip.File, path string) error {
 	targetPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return fmt.Errorf("Failed to resolve symlink: %s", err)
+		fmt.Printf("[WARN] Symlink %s points to a target that is outside the repo. Leaving existing symlink in place.\n", path)
+		return nil
 	}
 
 	symlinkPath := filepath.Join(filepath.Dir(path), f.FileInfo().Name())

--- a/file.go
+++ b/file.go
@@ -79,17 +79,17 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string, fetc
 	pathPrefix = filepath.Join(pathPrefix, filesToExtractFromZipPath)
 
 	// Iterate through the files in the archive.
-	for _, f := range r.File {
+	for _, file := range r.File {
 
 		// If the given file is in the filesToExtractFromZipPath, proceed
-		if strings.Index(f.Name, pathPrefix) == 0 {
+		if strings.Index(file.Name, pathPrefix) == 0 {
 
-			path := filepath.Join(localPath, strings.TrimPrefix(f.Name, pathPrefix))
+			path := filepath.Join(localPath, strings.TrimPrefix(file.Name, pathPrefix))
 
-			if f.FileInfo().IsDir() {
+			if file.FileInfo().IsDir() {
 				os.MkdirAll(path, 0777)
 			} else {
-				err = writeFileFromZip(f, path)
+				err = writeFileFromZip(file, path)
 				if err != nil {
 					return err
 				}
@@ -98,18 +98,18 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string, fetc
 	}
 
 	// Sym links may refer to files within the repo, in which case we first need to copy all files, and then process symlinks
-	if fetchOptions != nil && fetchOptions.ResolveSymlinks {
+	if cliArgResolveSymlinksIsPresent(fetchOptions) {
 		fmt.Println("--resolve-symlinks is set to true, so replacing symlinks with the contents of their targets")
 
-		for _, f := range r.File {
+		for _, file := range r.File {
 
 			// If the given file is in the filesToExtractFromZipPath, proceed
-			if strings.Index(f.Name, pathPrefix) == 0 {
+			if strings.Index(file.Name, pathPrefix) == 0 {
 
-				path := filepath.Join(localPath, strings.TrimPrefix(f.Name, pathPrefix))
+				path := filepath.Join(localPath, strings.TrimPrefix(file.Name, pathPrefix))
 
-				if IsSymLink(f) {
-					err := evalSymLinkAndCopyFiles(f, path)
+				if IsSymLink(file) {
+					err := evalSymLinkAndCopyFiles(file, path)
 					if err != nil {
 						return err
 					}
@@ -119,6 +119,10 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string, fetc
 	}
 
 	return nil
+}
+
+func cliArgResolveSymlinksIsPresent (options *FetchOptions) bool {
+	return options != nil && options.ResolveSymlinks
 }
 
 // Returns true if the given file is a symlink to a file or dir

--- a/file_test.go
+++ b/file_test.go
@@ -217,9 +217,10 @@ func TestDownloadZipFileWithBadRepoValues(t *testing.T) {
 func TestDownloadSymlink(t *testing.T) {
 	repoOwner := "gruntwork-io"
 	repoName := "fetch-test-public"
-	commitSha := "0a43e1c"
+	commitSha := "7549f0d4fb54782697beed421647dfa9f7c90d7f"
 
 	tmpDir := mkTmpDir(t)
+	fmt.Printf("tmpDir = %s\n", tmpDir)
 	gitHubCommit := newGitHubCommit(repoOwner, repoName, commitSha)
 
 	zipFilePath := downloadZipFile(t, gitHubCommit, "")

--- a/file_test.go
+++ b/file_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"fmt"
 	"strings"
+	"github.com/stretchr/testify/assert"
 )
 
 // Although other tests besides those in this file require this env var, this init() func will cover all tests.
@@ -213,6 +214,42 @@ func TestDownloadZipFileWithBadRepoValues(t *testing.T) {
 	}
 }
 
+func TestDownloadSymlink(t *testing.T) {
+	repoOwner := "gruntwork-io"
+	repoName := "fetch-test-public"
+	commitSha := "0a43e1c"
+
+	tmpDir := mkTmpDir(t)
+	gitHubCommit := newGitHubCommit(repoOwner, repoName, commitSha)
+
+	zipFilePath := downloadZipFile(t, gitHubCommit, "")
+	defer os.RemoveAll(zipFilePath)
+
+	extractZipFile(t, zipFilePath, "/", tmpDir)
+
+	expectedFile1Path := filepath.Join(tmpDir, "file3.txt")
+	assert.True(t, fileExists(expectedFile1Path), "Expected file to exist at %s", expectedFile1Path)
+
+	expectedFile1Contents := readFileContents(t, expectedFile1Path)
+	assert.Equal(t, "hello, world!\n", expectedFile1Contents, "Expected file contents to match.")
+
+	expectedFile2Path := filepath.Join(tmpDir, "symlinked-folder", "file1.txt")
+	expectedFile3Path := filepath.Join(tmpDir, "symlinked-folder", "file2.txt")
+	expectedFile4Path := filepath.Join(tmpDir, "symlinked-folder", "file3.txt")
+
+	assert.True(t, fileExists(expectedFile2Path), "Expected file to exist at %s", expectedFile2Path)
+	assert.True(t, fileExists(expectedFile3Path), "Expected file to exist at %s", expectedFile3Path)
+	assert.True(t, fileExists(expectedFile4Path), "Expected file to exist at %s", expectedFile4Path)
+
+	expectedFile2Contents := readFileContents(t, expectedFile2Path)
+	expectedFile3Contents := readFileContents(t, expectedFile3Path)
+	expectedFile4Contents := readFileContents(t, expectedFile4Path)
+
+	assert.Equal(t, "", expectedFile2Contents, "Expected file contents to match.")
+	assert.Equal(t, "", expectedFile3Contents, "Expected file contents to match.")
+	assert.Equal(t, "hello, world!\n", expectedFile4Contents, "Expected file contents to match.")
+}
+
 func TestExtractFiles(t *testing.T) {
 	t.Parallel()
 
@@ -267,6 +304,54 @@ func TestExtractFiles(t *testing.T) {
 		})
 
 	}
+}
+
+func mkTmpDir(t *testing.T) string {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	return tmpDir
+}
+
+func newGitHubCommit(repoOwner, repoName, commitSha string) *GitHubCommit {
+	gitHubCommit := &GitHubCommit{
+		Repo: GitHubRepo{
+			Owner: repoOwner,
+			Name: repoName,
+		},
+		CommitSha: commitSha,
+	}
+
+	return gitHubCommit
+}
+
+// Reminder: Make sure to call "defer os.RemoveAll(zipFilePath)" after calling this function
+func downloadZipFile(t *testing.T, gitHubCommit *GitHubCommit, gitHubToken string) string {
+	zipFilePath, err := downloadGithubZipFile(*gitHubCommit, "")
+	if err != nil {
+		t.Fatalf("Failed to download repo %s/%s at commmit sha \"%s\": %s", gitHubCommit.Repo.Owner, gitHubCommit.Repo.Name, gitHubCommit.CommitSha, err)
+	}
+
+	return zipFilePath
+}
+
+func extractZipFile(t *testing.T, zipFilePath string, filesToExtractFromZipPath string, localPath string) {
+	err := extractFiles(zipFilePath, filesToExtractFromZipPath, localPath)
+	if err != nil {
+		t.Fatalf("Failed to extract files: %s", err)
+	}
+}
+
+func readFileContents(t *testing.T, path string) string {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read file contents")
+	}
+
+	return string(bytes)
 }
 
 // Return ture if the given slice contains the given string

--- a/file_test.go
+++ b/file_test.go
@@ -220,13 +220,16 @@ func TestDownloadSymlink(t *testing.T) {
 	commitSha := "7549f0d4fb54782697beed421647dfa9f7c90d7f"
 
 	tmpDir := mkTmpDir(t)
-	fmt.Printf("tmpDir = %s\n", tmpDir)
 	gitHubCommit := newGitHubCommit(repoOwner, repoName, commitSha)
 
 	zipFilePath := downloadZipFile(t, gitHubCommit, "")
 	defer os.RemoveAll(zipFilePath)
 
-	extractZipFile(t, zipFilePath, "/", tmpDir)
+	fetchOptions := &FetchOptions{
+		ResolveSymlinks: true,
+	}
+
+	extractZipFile(t, zipFilePath, "/", tmpDir, fetchOptions)
 
 	expectedFile1Path := filepath.Join(tmpDir, "file3.txt")
 	assert.True(t, fileExists(expectedFile1Path), "Expected file to exist at %s", expectedFile1Path)
@@ -274,7 +277,7 @@ func TestExtractFiles(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		err = extractFiles(tc.localFilePath, tc.filePathToExtract, tempDir)
+		err = extractFiles(tc.localFilePath, tc.filePathToExtract, tempDir, nil)
 		if err != nil {
 			t.Fatalf("Failed to extract files: %s", err)
 		}
@@ -339,8 +342,8 @@ func downloadZipFile(t *testing.T, gitHubCommit *GitHubCommit, gitHubToken strin
 	return zipFilePath
 }
 
-func extractZipFile(t *testing.T, zipFilePath string, filesToExtractFromZipPath string, localPath string) {
-	err := extractFiles(zipFilePath, filesToExtractFromZipPath, localPath)
+func extractZipFile(t *testing.T, zipFilePath string, filesToExtractFromZipPath string, localPath string, fetchOptions *FetchOptions) {
+	err := extractFiles(zipFilePath, filesToExtractFromZipPath, localPath, fetchOptions)
 	if err != nil {
 		t.Fatalf("Failed to extract files: %s", err)
 	}

--- a/github_test.go
+++ b/github_test.go
@@ -156,7 +156,7 @@ func TestGetGitHubReleaseInfo(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(tc.expected, resp) {
-			t.Fatalf("Expected GitHub release %s but got GitHub release %s", tc.expected, resp)
+			t.Fatalf("Expected GitHub release %+v but got GitHub release %+v", tc.expected, resp)
 		}
 	}
 }
@@ -188,13 +188,13 @@ func TestDownloadReleaseAsset(t *testing.T) {
 		}
 
 		if err := DownloadReleaseAsset(repo, tc.assetId, tmpFile.Name()); err != nil {
-			t.Fatalf("Failed to download asset %s to %s from GitHub URL %s due to error: %s", tc.assetId, tmpFile.Name(), tc.repoUrl, err.Error())
+			t.Fatalf("Failed to download asset %d to %s from GitHub URL %s due to error: %s", tc.assetId, tmpFile.Name(), tc.repoUrl, err.Error())
 		}
 
 		defer os.Remove(tmpFile.Name())
 
 		if !fileExists(tmpFile.Name()) {
-			t.Fatalf("Got no errors downloading asset %s to %s from GitHub URL %s, but %s does not exist!", tc.assetId, tmpFile.Name(), tc.repoUrl, tmpFile.Name())
+			t.Fatalf("Got no errors downloading asset %d to %s from GitHub URL %s, but %s does not exist!", tc.assetId, tmpFile.Name(), tc.repoUrl, tmpFile.Name())
 		}
 	}
 }


### PR DESCRIPTION
While working in https://github.com/gruntwork-io/package-kafka (note to public users: this is a private repo) to enable the loading of bash mocks, I needed a way for [gruntwork-install](https://github.com/gruntwork-io/gruntwork-installer) to both download the module files and also convert a symlink in a module folder (e.g. `/module/foo/bash --> /_bash/live`) to a "hard link" that contains the same file or folder contents as the symlink target.

This PR implements that as `--resolve-symlinks`.

**Edit:** Note that this change is backwards compatible because the `--resolve-symlinks` options defaults to `false`.