### PR TITLE
support github enterprise by allowing custom api and base urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe
 Download the release asset `foo.exe` from a GitHub release hosted on a GitHub Enterprise instance running at `ghe.mycompany.com` where the tag is exactly `0.1.5`, and save it to `/tmp`:
 
 ```
-fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" --github-base-url="ghe.mycompany.com" --github-api-url="ghe.mycompany.com/api/v3" /tmp
+fetch --repo="https://ghe.mycompany.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" --github-base-url="ghe.mycompany.com" --github-api-url="ghe.mycompany.com/api/v3" /tmp
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The supported options are:
   downloading from private GitHub repos. **NOTE:** fetch will also look for this token using the `GITHUB_OAUTH_TOKEN`
   environment variable, which we recommend using instead of the command line option to ensure the token doesn't get
   saved in bash history.
-- `--github-api-version` (**Optional**): The used when fetching an artifact from a GitHub Enterprise instance.
-  The default version is `v3`. This is ignored when fetching from GitHub.com.
+- `--github-api-version` (**Optional**): Used when fetching an artifact from a GitHub Enterprise instance.
+  Defaults to `v3`. This is ignored when fetching from GitHub.com.
 
 The supported arguments are:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ authentication. Fetch makes it possible to handle all of these cases with a one-
 - Download a binary asset from a specific release.
 - Verify the SHA256 or SHA512 checksum of a binary asset.
 - Download from public repos, or from private repos by specifying a [GitHub Personal Access Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
+- Download from GitHub Enterprise.
 - When specifying a git tag, you can can specify either exactly the tag you want, or a [Tag Constraint Expression](#tag-constraint-expressions) to do things like "get the latest non-breaking version" of this repo. Note that fetch assumes git tags are specified according to [Semantic Versioning](http://semver.org/) principles.
 
 #### Quick examples
@@ -75,6 +76,8 @@ The supported options are:
   downloading from private GitHub repos. **NOTE:** fetch will also look for this token using the `GITHUB_OAUTH_TOKEN`
   environment variable, which we recommend using instead of the command line option to ensure the token doesn't get
   saved in bash history.
+- `--github-api-version` (**Optional**): The used when fetching an artifact from a GitHub Enterprise instance.
+  The default version is `v3`. This is ignored when fetching from GitHub.com.
 
 The supported arguments are:
 
@@ -157,7 +160,7 @@ fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe
 Download the release asset `foo.exe` from a GitHub release hosted on a GitHub Enterprise instance running at `ghe.mycompany.com` where the tag is exactly `0.1.5`, and save it to `/tmp`:
 
 ```
-fetch --repo="https://ghe.mycompany.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" --github-base-url="ghe.mycompany.com" --github-api-url="ghe.mycompany.com/api/v3" /tmp
+fetch --repo="https://ghe.mycompany.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" /tmp
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -152,6 +152,14 @@ Download the release asset `foo.exe` from a GitHub release where the tag is exac
 fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" /tmp
 ```
 
+#### Usage Example 7
+
+Download the release asset `foo.exe` from a GitHub release hosted on a GitHub Enterprise instance running at `ghe.mycompany.com` where the tag is exactly `0.1.5`, and save it to `/tmp`:
+
+```
+fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" --github-base-url="ghe.mycompany.com" --github-api-url="ghe.mycompany.com/api/v3" /tmp
+```
+
 ## License
 
 This code is released under the MIT License. See [LICENSE.txt](/LICENSE.txt).

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -16,8 +16,12 @@ const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA512="28d9e487c1001e3c28d915c9edd3ed37632f
 
 func TestVerifyReleaseAsset(t *testing.T) {
 	tmpDir := mkTempDir(t)
+  testInst := GitHubInstance{
+    BaseUrl: "github.com",
+    ApiUrl: "api.github.com",
+  }
 
-	githubRepo, err := ParseUrlIntoGitHubRepo(SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL, "")
+	githubRepo, err := ParseUrlIntoGitHubRepo(SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL, "", testInst)
 	if err != nil {
 		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
 	}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -16,10 +16,10 @@ const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA512="28d9e487c1001e3c28d915c9edd3ed37632f
 
 func TestVerifyReleaseAsset(t *testing.T) {
 	tmpDir := mkTempDir(t)
-  testInst := GitHubInstance{
-    BaseUrl: "github.com",
-    ApiUrl: "api.github.com",
-  }
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
 
 	githubRepo, err := ParseUrlIntoGitHubRepo(SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL, "", testInst)
 	if err != nil {

--- a/github.go
+++ b/github.go
@@ -19,6 +19,11 @@ type GitHubRepo struct {
 	Token   string // The personal access token to access this repo (if it's a private repo)
 }
 
+type GitHubInstance struct {
+  BaseUrl    string
+  ApiUrl     string
+}
+
 // Represents a specific git commit.
 // Note that code using GitHub Commit should respect the following hierarchy:
 // - CommitSha > BranchName > GitTag

--- a/github.go
+++ b/github.go
@@ -69,6 +69,34 @@ type GitHubReleaseAsset struct {
 	Name string
 }
 
+func ParseUrlIntoGithubInstance(url string, apiv string) (GitHubInstance, *FetchError) {
+  var instance GitHubInstance
+
+  regex, regexErr := regexp.Compile("https?://(?:www\\.)?(.+?\\.com).*")
+  if regexErr != nil {
+		return instance, newError(GITHUB_REPO_URL_MALFORMED_OR_NOT_PARSEABLE, fmt.Sprintf("GitHub Repo URL %s is malformed.", url))
+  }
+
+  matches := regex.FindStringSubmatch(url)
+  if len(matches) != 2 {
+		return instance, newError(GITHUB_REPO_URL_MALFORMED_OR_NOT_PARSEABLE, fmt.Sprintf("GitHub Repo URL %s could not be parsed correctly", url))
+  }
+
+  baseUrl := matches[1]
+  apiUrl := "api.github.com"
+  if baseUrl != "github.com" && baseUrl != "www.github.com" {
+    fmt.Printf("Assuming GitHub Enterprise since the provided url (%s) does not appear to be for GitHub.com\n", url)
+    apiUrl = baseUrl + "/api/" + apiv
+  }
+
+  instance = GitHubInstance{
+    BaseUrl: baseUrl,
+    ApiUrl: apiUrl,
+  }
+
+  return instance, nil
+}
+
 // Fetch all tags from the given GitHub repo
 func FetchTags(githubRepoUrl string, githubBaseUrl string, githubApiUrl string, githubToken string) ([]string, *FetchError) {
 	var tagsString []string

--- a/github.go
+++ b/github.go
@@ -98,10 +98,10 @@ func ParseUrlIntoGithubInstance(url string, apiv string) (GitHubInstance, *Fetch
 }
 
 // Fetch all tags from the given GitHub repo
-func FetchTags(githubRepoUrl string, githubBaseUrl string, githubApiUrl string, githubToken string) ([]string, *FetchError) {
+func FetchTags(githubRepoUrl string, githubToken string, instance GitHubInstance) ([]string, *FetchError) {
 	var tagsString []string
 
-	repo, err := ParseUrlIntoGitHubRepo(githubRepoUrl, githubBaseUrl, githubApiUrl, githubToken)
+	repo, err := ParseUrlIntoGitHubRepo(githubRepoUrl, githubToken, instance)
 	if err != nil {
 		return tagsString, wrapError(err)
 	}
@@ -131,10 +131,10 @@ func FetchTags(githubRepoUrl string, githubBaseUrl string, githubApiUrl string, 
 }
 
 // Convert a URL into a GitHubRepo struct
-func ParseUrlIntoGitHubRepo(url string, githubBaseUrl string, githubApiUrl string, token string) (GitHubRepo, *FetchError) {
+func ParseUrlIntoGitHubRepo(url string, token string, instance GitHubInstance) (GitHubRepo, *FetchError) {
 	var gitHubRepo GitHubRepo
 
-	regex, regexErr := regexp.Compile("https?://(?:www\\.)?" + githubBaseUrl + "/(.+?)/(.+?)(?:$|\\?|#|/)")
+	regex, regexErr := regexp.Compile("https?://(?:www\\.)?" + instance.BaseUrl + "/(.+?)/(.+?)(?:$|\\?|#|/)")
 	if regexErr != nil {
 		return gitHubRepo, newError(GITHUB_REPO_URL_MALFORMED_OR_NOT_PARSEABLE, fmt.Sprintf("GitHub Repo URL %s is malformed.", url))
 	}
@@ -146,8 +146,8 @@ func ParseUrlIntoGitHubRepo(url string, githubBaseUrl string, githubApiUrl strin
 
 	gitHubRepo = GitHubRepo{
 		Url:     url,
-		BaseUrl: githubBaseUrl,
-		ApiUrl:  githubApiUrl,
+		BaseUrl: instance.BaseUrl,
+		ApiUrl:  instance.ApiUrl,
 		Owner:   matches[1],
 		Name:    matches[2],
 		Token:   token,

--- a/github.go
+++ b/github.go
@@ -20,8 +20,8 @@ type GitHubRepo struct {
 }
 
 type GitHubInstance struct {
-  BaseUrl    string
-  ApiUrl     string
+	BaseUrl string
+	ApiUrl  string
 }
 
 // Represents a specific git commit.
@@ -70,31 +70,31 @@ type GitHubReleaseAsset struct {
 }
 
 func ParseUrlIntoGithubInstance(url string, apiv string) (GitHubInstance, *FetchError) {
-  var instance GitHubInstance
+	var instance GitHubInstance
 
-  regex, regexErr := regexp.Compile("https?://(?:www\\.)?(.+?\\.com).*")
-  if regexErr != nil {
+	regex, regexErr := regexp.Compile("https?://(?:www\\.)?(.+?\\.com).*")
+	if regexErr != nil {
 		return instance, newError(GITHUB_REPO_URL_MALFORMED_OR_NOT_PARSEABLE, fmt.Sprintf("GitHub Repo URL %s is malformed.", url))
-  }
+	}
 
-  matches := regex.FindStringSubmatch(url)
-  if len(matches) != 2 {
+	matches := regex.FindStringSubmatch(url)
+	if len(matches) != 2 {
 		return instance, newError(GITHUB_REPO_URL_MALFORMED_OR_NOT_PARSEABLE, fmt.Sprintf("GitHub Repo URL %s could not be parsed correctly", url))
-  }
+	}
 
-  baseUrl := matches[1]
-  apiUrl := "api.github.com"
-  if baseUrl != "github.com" && baseUrl != "www.github.com" {
-    fmt.Printf("Assuming GitHub Enterprise since the provided url (%s) does not appear to be for GitHub.com\n", url)
-    apiUrl = baseUrl + "/api/" + apiv
-  }
+	baseUrl := matches[1]
+	apiUrl := "api.github.com"
+	if baseUrl != "github.com" && baseUrl != "www.github.com" {
+		fmt.Printf("Assuming GitHub Enterprise since the provided url (%s) does not appear to be for GitHub.com\n", url)
+		apiUrl = baseUrl + "/api/" + apiv
+	}
 
-  instance = GitHubInstance{
-    BaseUrl: baseUrl,
-    ApiUrl: apiUrl,
-  }
+	instance = GitHubInstance{
+		BaseUrl: baseUrl,
+		ApiUrl:  apiUrl,
+	}
 
-  return instance, nil
+	return instance, nil
 }
 
 // Fetch all tags from the given GitHub repo
@@ -198,7 +198,7 @@ func createGitHubRepoUrlForPath(repo GitHubRepo, path string) string {
 func callGitHubApi(repo GitHubRepo, path string, customHeaders map[string]string) (*http.Response, *FetchError) {
 	httpClient := &http.Client{}
 
-	request, err := http.NewRequest("GET", fmt.Sprintf("https://" + repo.ApiUrl + "/%s", path), nil)
+	request, err := http.NewRequest("GET", fmt.Sprintf("https://"+repo.ApiUrl+"/%s", path), nil)
 	if err != nil {
 		return nil, wrapError(err)
 	}

--- a/github_test.go
+++ b/github_test.go
@@ -47,6 +47,54 @@ func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 	}
 }
 
+func TestParseUrlIntoGithubInstance(t *testing.T) {
+  t.Parallel()
+
+  ghTestInst := GitHubInstance{
+    BaseUrl: "github.com",
+    ApiUrl: "api.github.com",
+  }
+  gheTestInst := GitHubInstance{
+    BaseUrl: "ghe.mycompany.com",
+    ApiUrl: "ghe.mycompany.com/api/v3",
+  }
+  myCoTestInst := GitHubInstance{
+    BaseUrl: "mycogithub.com",
+    ApiUrl: "mycogithub.com/api/v3",
+  }
+
+  cases := []struct {
+    repoUrl      string
+    apiv         string
+    expectedInst GitHubInstance
+  }{
+		{"http://www.github.com/gruntwork-io/script-modules/", "", ghTestInst},
+		{"https://www.github.com/gruntwork-io/script-modules/", "", ghTestInst},
+		{"http://github.com/gruntwork-io/script-modules/", "", ghTestInst},
+		{"http://www.ghe.mycompany.com/gruntwork-io/script-modules", "v3", gheTestInst},
+		{"https://www.ghe.mycompany.com/gruntwork-io/script-modules", "v3", gheTestInst},
+		{"http://ghe.mycompany.com/gruntwork-io/script-modules", "v3", gheTestInst},
+		{"http://www.mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
+		{"https://www.mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
+		{"http://mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
+  }
+
+	for _, tc := range cases {
+		inst, err := ParseUrlIntoGithubInstance(tc.repoUrl, tc.apiv)
+		if err != nil {
+			t.Fatalf("error extracting url %s into a GitHubRepo struct: %s", tc.repoUrl, err)
+		}
+
+		if inst.BaseUrl != tc.expectedInst.BaseUrl {
+			t.Fatalf("while extracting %s, expected owner %s, received %s", tc.repoUrl, tc.expectedInst.BaseUrl, inst.BaseUrl)
+		}
+
+		if inst.ApiUrl != tc.expectedInst.ApiUrl {
+			t.Fatalf("while extracting %s, expected name %s, received %s", tc.repoUrl, tc.expectedInst.ApiUrl, inst.ApiUrl)
+		}
+  }
+}
+
 func TestParseUrlIntoGitHubRepo(t *testing.T) {
 	t.Parallel()
 

--- a/github_test.go
+++ b/github_test.go
@@ -113,11 +113,11 @@ func TestParseUrlIntoGithubInstance(t *testing.T) {
 		}
 
 		if inst.BaseUrl != tc.expectedInst.BaseUrl {
-			t.Fatalf("while extracting %s, expected owner %s, received %s", tc.repoUrl, tc.expectedInst.BaseUrl, inst.BaseUrl)
+			t.Fatalf("while parsing %s, expected base url %s, received %s", tc.repoUrl, tc.expectedInst.BaseUrl, inst.BaseUrl)
 		}
 
 		if inst.ApiUrl != tc.expectedInst.ApiUrl {
-			t.Fatalf("while extracting %s, expected name %s, received %s", tc.repoUrl, tc.expectedInst.ApiUrl, inst.ApiUrl)
+			t.Fatalf("while parsing %s, expected api url %s, received %s", tc.repoUrl, tc.expectedInst.ApiUrl, inst.ApiUrl)
 		}
 	}
 }

--- a/github_test.go
+++ b/github_test.go
@@ -156,7 +156,7 @@ func TestGetGitHubReleaseInfo(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(tc.expected, resp) {
-			t.Fatalf("Expected GitHub release %s but got GitHub release %s", tc.expected, resp)
+			t.Fatalf("Expected GitHub release %v but got GitHub release %v", tc.expected, resp)
 		}
 	}
 }
@@ -188,13 +188,13 @@ func TestDownloadReleaseAsset(t *testing.T) {
 		}
 
 		if err := DownloadReleaseAsset(repo, tc.assetId, tmpFile.Name()); err != nil {
-			t.Fatalf("Failed to download asset %s to %s from GitHub URL %s due to error: %s", tc.assetId, tmpFile.Name(), tc.repoUrl, err.Error())
+			t.Fatalf("Failed to download asset %d to %s from GitHub URL %s due to error: %s", tc.assetId, tmpFile.Name(), tc.repoUrl, err.Error())
 		}
 
 		defer os.Remove(tmpFile.Name())
 
 		if !fileExists(tmpFile.Name()) {
-			t.Fatalf("Got no errors downloading asset %s to %s from GitHub URL %s, but %s does not exist!", tc.assetId, tmpFile.Name(), tc.repoUrl, tmpFile.Name())
+			t.Fatalf("Got no errors downloading asset %d to %s from GitHub URL %s, but %s does not exist!", tc.assetId, tmpFile.Name(), tc.repoUrl, tmpFile.Name())
 		}
 	}
 }

--- a/github_test.go
+++ b/github_test.go
@@ -59,13 +59,33 @@ func TestParseUrlIntoGithubInstance(t *testing.T) {
 		BaseUrl: "github.com",
 		ApiUrl:  "api.github.com",
 	}
+	wwwGhTestInst := GitHubInstance{
+		BaseUrl: "www.github.com",
+		ApiUrl:  "api.github.com",
+	}
 	gheTestInst := GitHubInstance{
 		BaseUrl: "ghe.mycompany.com",
 		ApiUrl:  "ghe.mycompany.com/api/v3",
 	}
+	wwwGheTestInst := GitHubInstance{
+		BaseUrl: "www.ghe.mycompany.com",
+		ApiUrl:  "www.ghe.mycompany.com/api/v3",
+	}
 	myCoTestInst := GitHubInstance{
 		BaseUrl: "mycogithub.com",
 		ApiUrl:  "mycogithub.com/api/v3",
+	}
+	wwwMyCoTestInst := GitHubInstance{
+		BaseUrl: "www.mycogithub.com",
+		ApiUrl:  "www.mycogithub.com/api/v3",
+	}
+	localTestInst := GitHubInstance{
+		BaseUrl: "mycogithub.local",
+		ApiUrl:  "mycogithub.local/api/v3",
+	}
+	netTestInst := GitHubInstance{
+		BaseUrl: "mycogithub.net",
+		ApiUrl:  "mycogithub.net/api/v3",
 	}
 
 	cases := []struct {
@@ -73,15 +93,17 @@ func TestParseUrlIntoGithubInstance(t *testing.T) {
 		apiv         string
 		expectedInst GitHubInstance
 	}{
-		{"http://www.github.com/gruntwork-io/script-modules/", "", ghTestInst},
-		{"https://www.github.com/gruntwork-io/script-modules/", "", ghTestInst},
+		{"http://www.github.com/gruntwork-io/script-modules/", "", wwwGhTestInst},
+		{"https://www.github.com/gruntwork-io/script-modules/", "", wwwGhTestInst},
 		{"http://github.com/gruntwork-io/script-modules/", "", ghTestInst},
-		{"http://www.ghe.mycompany.com/gruntwork-io/script-modules", "v3", gheTestInst},
-		{"https://www.ghe.mycompany.com/gruntwork-io/script-modules", "v3", gheTestInst},
+		{"http://www.ghe.mycompany.com/gruntwork-io/script-modules", "v3", wwwGheTestInst},
+		{"https://www.ghe.mycompany.com/gruntwork-io/script-modules", "v3", wwwGheTestInst},
 		{"http://ghe.mycompany.com/gruntwork-io/script-modules", "v3", gheTestInst},
-		{"http://www.mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
-		{"https://www.mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
+		{"http://www.mycogithub.com/gruntwork-io/script-modules", "v3", wwwMyCoTestInst},
+		{"https://www.mycogithub.com/gruntwork-io/script-modules", "v3", wwwMyCoTestInst},
 		{"http://mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
+		{"http://mycogithub.local/gruntwork-io/script-modules", "v3", localTestInst},
+		{"http://mycogithub.net/gruntwork-io/script-modules", "v3", netTestInst},
 	}
 
 	for _, tc := range cases {

--- a/github_test.go
+++ b/github_test.go
@@ -1,25 +1,25 @@
 package main
 
 import (
-	"testing"
+	"io/ioutil"
 	"os"
 	"reflect"
-	"io/ioutil"
+	"testing"
 )
 
 func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 	t.Parallel()
-  testInst := GitHubInstance{
-    BaseUrl: "github.com",
-    ApiUrl: "api.github.com",
-  }
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
 
 	cases := []struct {
 		repoUrl          string
 		firstReleaseTag  string
 		lastReleaseTag   string
 		gitHubOAuthToken string
-    testInst         GitHubInstance
+		testInst         GitHubInstance
 	}{
 		// Test on a public repo whose sole purpose is to be a test fixture for this tool
 		{"https://github.com/gruntwork-io/fetch-test-public", "v0.0.1", "v0.0.3", "", testInst},
@@ -53,26 +53,26 @@ func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 }
 
 func TestParseUrlIntoGithubInstance(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  ghTestInst := GitHubInstance{
-    BaseUrl: "github.com",
-    ApiUrl: "api.github.com",
-  }
-  gheTestInst := GitHubInstance{
-    BaseUrl: "ghe.mycompany.com",
-    ApiUrl: "ghe.mycompany.com/api/v3",
-  }
-  myCoTestInst := GitHubInstance{
-    BaseUrl: "mycogithub.com",
-    ApiUrl: "mycogithub.com/api/v3",
-  }
+	ghTestInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+	gheTestInst := GitHubInstance{
+		BaseUrl: "ghe.mycompany.com",
+		ApiUrl:  "ghe.mycompany.com/api/v3",
+	}
+	myCoTestInst := GitHubInstance{
+		BaseUrl: "mycogithub.com",
+		ApiUrl:  "mycogithub.com/api/v3",
+	}
 
-  cases := []struct {
-    repoUrl      string
-    apiv         string
-    expectedInst GitHubInstance
-  }{
+	cases := []struct {
+		repoUrl      string
+		apiv         string
+		expectedInst GitHubInstance
+	}{
 		{"http://www.github.com/gruntwork-io/script-modules/", "", ghTestInst},
 		{"https://www.github.com/gruntwork-io/script-modules/", "", ghTestInst},
 		{"http://github.com/gruntwork-io/script-modules/", "", ghTestInst},
@@ -82,7 +82,7 @@ func TestParseUrlIntoGithubInstance(t *testing.T) {
 		{"http://www.mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
 		{"https://www.mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
 		{"http://mycogithub.com/gruntwork-io/script-modules", "v3", myCoTestInst},
-  }
+	}
 
 	for _, tc := range cases {
 		inst, err := ParseUrlIntoGithubInstance(tc.repoUrl, tc.apiv)
@@ -97,30 +97,30 @@ func TestParseUrlIntoGithubInstance(t *testing.T) {
 		if inst.ApiUrl != tc.expectedInst.ApiUrl {
 			t.Fatalf("while extracting %s, expected name %s, received %s", tc.repoUrl, tc.expectedInst.ApiUrl, inst.ApiUrl)
 		}
-  }
+	}
 }
 
 func TestParseUrlIntoGitHubRepo(t *testing.T) {
 	t.Parallel()
-  ghTestInst := GitHubInstance{
-    BaseUrl: "github.com",
-    ApiUrl: "api.github.com",
-  }
-  gheTestInst := GitHubInstance{
-    BaseUrl: "ghe.mycompany.com",
-    ApiUrl: "ghe.mycompany.com/api/v3",
-  }
-  myCoTestInst := GitHubInstance{
-    BaseUrl: "mycogithub.com",
-    ApiUrl: "mycogithub.com/api/v3",
-  }
+	ghTestInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+	gheTestInst := GitHubInstance{
+		BaseUrl: "ghe.mycompany.com",
+		ApiUrl:  "ghe.mycompany.com/api/v3",
+	}
+	myCoTestInst := GitHubInstance{
+		BaseUrl: "mycogithub.com",
+		ApiUrl:  "mycogithub.com/api/v3",
+	}
 
 	cases := []struct {
 		repoUrl  string
 		owner    string
 		name     string
 		token    string
-    testInst GitHubInstance
+		testInst GitHubInstance
 	}{
 		{"https://github.com/brikis98/ping-play", "brikis98", "ping-play", "", ghTestInst},
 		{"http://github.com/brikis98/ping-play", "brikis98", "ping-play", "", ghTestInst},
@@ -162,7 +162,7 @@ func TestParseUrlIntoGitHubRepo(t *testing.T) {
 
 func TestParseUrlThrowsErrorOnMalformedUrl(t *testing.T) {
 	t.Parallel()
-  testInst := GitHubInstance{}
+	testInst := GitHubInstance{}
 
 	cases := []struct {
 		repoUrl string
@@ -205,10 +205,10 @@ func TestGetGitHubReleaseInfo(t *testing.T) {
 		Assets: []GitHubReleaseAsset{},
 	}
 
-  testInst := GitHubInstance{
-    BaseUrl: "github.com",
-    ApiUrl: "api.github.com",
-  }
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
 
 	cases := []struct {
 		repoUrl   string
@@ -242,10 +242,10 @@ func TestDownloadReleaseAsset(t *testing.T) {
 
 	token := os.Getenv("GITHUB_OAUTH_TOKEN")
 
-  testInst := GitHubInstance{
-    BaseUrl: "github.com",
-    ApiUrl: "api.github.com",
-  }
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
 
 	cases := []struct {
 		repoUrl   string

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  OPTION_GITHUB_API_VERSION,
-      Value: "v3",
+			Value: "v3",
 			Usage: "The api version of the GitHub instance. If left blank, v3 will be used.\n\tThis will only be used if the repo url is not a github.com url.",
 		},
 	}
@@ -113,10 +113,10 @@ func runFetch(c *cli.Context) error {
 		return err
 	}
 
-  instance, fetchErr := ParseUrlIntoGithubInstance(options.RepoUrl, options.GithubApiVersion)
-  if fetchErr != nil {
-    return fetchErr
-  }
+	instance, fetchErr := ParseUrlIntoGithubInstance(options.RepoUrl, options.GithubApiVersion)
+	if fetchErr != nil {
+		return fetchErr
+	}
 
 	// Get the tags for the given repo
 	tags, fetchErr := FetchTags(options.RepoUrl, options.GithubToken, instance)

--- a/main.go
+++ b/main.go
@@ -23,8 +23,7 @@ type FetchOptions struct {
 	ReleaseAssetChecksum     string
 	ReleaseAssetChecksumAlgo string
 	LocalDownloadPath        string
-	GithubBaseUrl            string
-	GithubApiUrl             string
+	GithubApiVersion         string
 }
 
 const OPTION_REPO = "repo"
@@ -36,8 +35,7 @@ const OPTION_SOURCE_PATH = "source-path"
 const OPTION_RELEASE_ASSET = "release-asset"
 const OPTION_RELEASE_ASSET_CHECKSUM = "release-asset-checksum"
 const OPTION_RELEASE_ASSET_CHECKSUM_ALGO = "release-asset-checksum-algo"
-const OPTION_GITHUB_BASE_URL = "github-base-url"
-const OPTION_GITHUB_API_URL = "github-api-url"
+const OPTION_GITHUB_API_VERSION = "github-api-version"
 
 const ENV_VAR_GITHUB_TOKEN = "GITHUB_OAUTH_TOKEN"
 
@@ -87,12 +85,9 @@ func main() {
 			Usage: "The algorithm Fetch will use to compute a checksum of the release asset. Acceptable values\n\tare \"sha256\" and \"sha512\".",
 		},
 		cli.StringFlag{
-			Name:  OPTION_GITHUB_BASE_URL,
-			Usage: "The base url of the GitHub instance. If left blank, github.com will be used.",
-		},
-		cli.StringFlag{
-			Name:  OPTION_GITHUB_API_URL,
-			Usage: "The api url of the GitHub instance. If left blank, api.github.com will be used.",
+			Name:  OPTION_GITHUB_API_VERSION,
+      Value: "v3",
+			Usage: "The api version of the GitHub instance. If left blank, v3 will be used.\n\tThis will only be used if the repo url is not a github.com url.",
 		},
 	}
 
@@ -205,8 +200,7 @@ func parseOptions(c *cli.Context) FetchOptions {
 		ReleaseAssetChecksum:     c.String(OPTION_RELEASE_ASSET_CHECKSUM),
 		ReleaseAssetChecksumAlgo: c.String(OPTION_RELEASE_ASSET_CHECKSUM_ALGO),
 		LocalDownloadPath:        localDownloadPath,
-		GithubBaseUrl:            c.String(OPTION_GITHUB_BASE_URL),
-		GithubApiUrl:             c.String(OPTION_GITHUB_API_URL),
+		GithubApiVersion:         c.String(OPTION_GITHUB_API_VERSION),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ type FetchOptions struct {
 	ReleaseAssetChecksum     string
 	ReleaseAssetChecksumAlgo string
 	LocalDownloadPath        string
+	GithubBaseUrl            string
+	GithubApiUrl             string
 }
 
 const OPTION_REPO = "repo"
@@ -34,6 +36,8 @@ const OPTION_SOURCE_PATH = "source-path"
 const OPTION_RELEASE_ASSET = "release-asset"
 const OPTION_RELEASE_ASSET_CHECKSUM = "release-asset-checksum"
 const OPTION_RELEASE_ASSET_CHECKSUM_ALGO = "release-asset-checksum-algo"
+const OPTION_GITHUB_BASE_URL = "github-base-url"
+const OPTION_GITHUB_API_URL = "github-api-url"
 
 const ENV_VAR_GITHUB_TOKEN = "GITHUB_OAUTH_TOKEN"
 
@@ -82,6 +86,14 @@ func main() {
 			Name:  OPTION_RELEASE_ASSET_CHECKSUM_ALGO,
 			Usage: "The algorithm Fetch will use to compute a checksum of the release asset. Acceptable values\n\tare \"sha256\" and \"sha512\".",
 		},
+		cli.StringFlag{
+			Name:  OPTION_GITHUB_BASE_URL,
+			Usage: "The base url of the GitHub instance. If left blank, github.com will be used.",
+		},
+		cli.StringFlag{
+			Name:  OPTION_GITHUB_API_URL,
+			Usage: "The api url of the GitHub instance. If left blank, api.github.com will be used.",
+		},
 	}
 
 	app.Action = runFetchWrapper
@@ -107,7 +119,7 @@ func runFetch(c *cli.Context) error {
 	}
 
 	// Get the tags for the given repo
-	tags, fetchErr := FetchTags(options.RepoUrl, options.GithubToken)
+	tags, fetchErr := FetchTags(options.RepoUrl, options.GithubBaseUrl, options.GithubApiUrl, options.GithubToken)
 	if fetchErr != nil {
 		if fetchErr.errorCode == INVALID_GITHUB_TOKEN_OR_ACCESS_DENIED {
 			return errors.New(getErrorMessage(INVALID_GITHUB_TOKEN_OR_ACCESS_DENIED, fetchErr.details))
@@ -133,7 +145,7 @@ func runFetch(c *cli.Context) error {
 	}
 
 	// Prepare the vars we'll need to download
-	repo, fetchErr := ParseUrlIntoGitHubRepo(options.RepoUrl, options.GithubToken)
+	repo, fetchErr := ParseUrlIntoGitHubRepo(options.RepoUrl, options.GithubBaseUrl, options.GithubApiUrl, options.GithubToken)
 	if fetchErr != nil {
 		return fmt.Errorf("Error occurred while parsing GitHub URL: %s", fetchErr)
 	}
@@ -188,6 +200,8 @@ func parseOptions(c *cli.Context) FetchOptions {
 		ReleaseAssetChecksum:     c.String(OPTION_RELEASE_ASSET_CHECKSUM),
 		ReleaseAssetChecksumAlgo: c.String(OPTION_RELEASE_ASSET_CHECKSUM_ALGO),
 		LocalDownloadPath:        localDownloadPath,
+		GithubBaseUrl:            c.String(OPTION_GITHUB_BASE_URL),
+		GithubApiUrl:             c.String(OPTION_GITHUB_API_URL),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -118,8 +118,13 @@ func runFetch(c *cli.Context) error {
 		return err
 	}
 
+  instance, fetchErr := ParseUrlIntoGithubInstance(options.RepoUrl, options.GithubApiVersion)
+  if fetchErr != nil {
+    return fetchErr
+  }
+
 	// Get the tags for the given repo
-	tags, fetchErr := FetchTags(options.RepoUrl, options.GithubBaseUrl, options.GithubApiUrl, options.GithubToken)
+	tags, fetchErr := FetchTags(options.RepoUrl, options.GithubToken, instance)
 	if fetchErr != nil {
 		if fetchErr.errorCode == INVALID_GITHUB_TOKEN_OR_ACCESS_DENIED {
 			return errors.New(getErrorMessage(INVALID_GITHUB_TOKEN_OR_ACCESS_DENIED, fetchErr.details))
@@ -145,7 +150,7 @@ func runFetch(c *cli.Context) error {
 	}
 
 	// Prepare the vars we'll need to download
-	repo, fetchErr := ParseUrlIntoGitHubRepo(options.RepoUrl, options.GithubBaseUrl, options.GithubApiUrl, options.GithubToken)
+	repo, fetchErr := ParseUrlIntoGitHubRepo(options.RepoUrl, options.GithubToken, instance)
 	if fetchErr != nil {
 		return fmt.Errorf("Error occurred while parsing GitHub URL: %s", fetchErr)
 	}


### PR DESCRIPTION
Fetch seems like a much more enjoyable way to fetch release artifacts from GitHub on the command line. More enjoyable then writing a curl script and more reusable. 

However, I'm working with repos in both GitHub Enterprise (GHE) and GitHub.com. These changes make it so that I can pass in the URLs (base and api) of the GHE instance that I'm working with and be able to fetch artifacts from there.

I did some basic smoke testing on this. I was able to fetch from GHE. I can add/fix tests if it's required for merge, it just won't be until tomorrow. 