### PR TITLE
Update dependency reference 

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"os"
-	"github.com/codegangsta/cli"
+	"gopkg.in/urfave/cli.v1"
 	"fmt"
 	"errors"
 	"path"


### PR DESCRIPTION
github.com/codegangsta/cli has moved to gopkg.in/urfave/cli.v1. Github is automatically redirecting requests to codegangsta, but it is recommended to update the references.