### PR TITLE
Use regex for release asset download

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ authentication. Fetch makes it possible to handle all of these cases with a one-
 
 - Download from a specific git tag, branch, or commit SHA.
 - Download a single file, a subset of files, or all files from the repo.
-- Download a binary asset from a specific release.
+- Download one or more binary assets from a specific release that match a regular expression.
 - Verify the SHA256 or SHA512 checksum of a binary asset.
 - Download from public repos, or from private repos by specifying a [GitHub Personal Access Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
 - Download from GitHub Enterprise.
@@ -31,10 +31,10 @@ Download folder `/baz` from tag `0.1.3` of a GitHub repo and save it to `/tmp/ba
 fetch --repo="https://github.com/foo/bar" --tag="0.1.3" --source-path="/baz" /tmp/baz
 ```
 
-Download the release asset `foo.exe` from release `0.1.5` and save it to `/tmp`:
+Download all release assets matching the regular expression, `foo_linux-.*` from release `0.1.5` and save them to `/tmp`:
 
 ```
-fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" /tmp
+fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo_linux-.*" /tmp
 ```
 
 See more examples in the [Examples section](#examples).
@@ -66,10 +66,11 @@ The supported options are:
 - `--source-path` (**Optional**): The source path to download from the repo (e.g. `--source-path=/folder` will download
   the `/folder` path and all files below it). By default, all files are downloaded from the repo unless `--source-path`
   or `--release-asset` is specified. This option can be specified more than once.
-- `--release-asset` (**Optional**): The name of a release asset--that is, a binary uploaded to a [GitHub
+- `--release-asset` (**Optional**): A regular expression matching release assets--these are binary files uploaded to a [GitHub
   Release](https://help.github.com/articles/creating-releases/)--to download. It only works with the `--tag` option.
 - `--release-asset-checksum` (**Optional**): The checksum that a release asset should have. Fetch will fail if this value
-  is non-empty and does not match the checksum computed by Fetch.
+  is non-empty and does not match the checksum computed by Fetch, or if more than 1 assets are matched by the release-asset
+  regular expression.
 - `--release-asset-checksum-algo` (**Optional**): The algorithm fetch will use to compute a checksum of the release asset.
   Supported values are `sha256` and `sha512`.
 - `--github-oauth-token` (**Optional**): A [GitHub Personal Access

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Download folder `/baz` from tag `0.1.3` of a GitHub repo and save it to `/tmp/ba
 fetch --repo="https://github.com/foo/bar" --tag="0.1.3" --source-path="/baz" /tmp/baz
 ```
 
+Download a release asset matching named `foo.exe` from release `0.1.5` and save them to `/tmp`:
+
+```
+fetch --repo="https://github.com/foo/bar" --tag="0.1.5" --release-asset="foo.exe" /tmp
+```
+
 Download all release assets matching the regular expression, `foo_linux-.*` from release `0.1.5` and save them to `/tmp`:
 
 ```

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,18 +1,19 @@
 package main
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-const SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL ="https://github.com/gruntwork-io/health-checker"
-const SAMPLE_RELEASE_ASSET_VERSION="v0.0.2"
-const SAMPLE_RELEASE_ASSET_NAME="health-checker_linux_amd64"
+const SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL = "https://github.com/gruntwork-io/health-checker"
+const SAMPLE_RELEASE_ASSET_VERSION = "v0.0.2"
+const SAMPLE_RELEASE_ASSET_NAME = "health-checker_linux_amd64"
 
 // Checksums can be computed by running "shasum -a [256|512] /path/to/file" on any UNIX system
-const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA256="4314590d802760c29a532e2ef22689d4656d184b3daa63f96bc8b8f76f5d22f0"
-const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA512="28d9e487c1001e3c28d915c9edd3ed37632f10b923bd94d4d9ac6d28c0af659abbe2456da167763d51def2182fef01c3f73c67edf527d4ed1389a28ba10db332"
+const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA256 = "4314590d802760c29a532e2ef22689d4656d184b3daa63f96bc8b8f76f5d22f0"
+const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA512 = "28d9e487c1001e3c28d915c9edd3ed37632f10b923bd94d4d9ac6d28c0af659abbe2456da167763d51def2182fef01c3f73c67edf527d4ed1389a28ba10db332"
 
 func TestVerifyReleaseAsset(t *testing.T) {
 	tmpDir := mkTempDir(t)
@@ -26,17 +27,21 @@ func TestVerifyReleaseAsset(t *testing.T) {
 		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
 	}
 
-	assetPath, fetchErr := downloadReleaseAsset(SAMPLE_RELEASE_ASSET_NAME, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_NAME, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
 	if fetchErr != nil {
 		t.Fatalf("Failed to download release asset: %s", fetchErr)
 	}
 
-	checksumSha256, fetchErr := computeChecksum(assetPath, "sha256")
+	if len(assetPaths) != 1 {
+		t.Fatalf("Incorrect number of release assets: %s", len(assetPaths))
+	}
+
+	checksumSha256, fetchErr := computeChecksum(assetPaths[0], "sha256")
 	if fetchErr != nil {
 		t.Fatalf("Failed to compute file checksum: %s", fetchErr)
 	}
 
-	checksumSha512, fetchErr := computeChecksum(assetPath, "sha512")
+	checksumSha512, fetchErr := computeChecksum(assetPaths[0], "sha512")
 	if fetchErr != nil {
 		t.Fatalf("Failed to compute file checksum: %s", fetchErr)
 	}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -15,6 +15,16 @@ const SAMPLE_RELEASE_ASSET_NAME = "health-checker_linux_amd64"
 const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA256 = "4314590d802760c29a532e2ef22689d4656d184b3daa63f96bc8b8f76f5d22f0"
 const SAMPLE_RELEASE_ASSET_CHECKSUM_SHA512 = "28d9e487c1001e3c28d915c9edd3ed37632f10b923bd94d4d9ac6d28c0af659abbe2456da167763d51def2182fef01c3f73c67edf527d4ed1389a28ba10db332"
 
+var SAMPLE_RELEASE_ASSET_CHECKSUMS_SHA256 = map[string]bool{
+	"4314590d802760c29a532e2ef22689d4656d184b3daa63f96bc8b8f76f5d22f0": true,
+	"de31de3055a2374d3bb38d847323e39821265ae611d990cffaa6f80a11ad2609": true,
+}
+
+var SAMPLE_RELEASE_ASSET_CHECKSUMS_SHA256_NO_MATCH = map[string]bool{
+	"XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX": true,
+	"YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY": true,
+}
+
 func TestVerifyReleaseAsset(t *testing.T) {
 	tmpDir := mkTempDir(t)
 	testInst := GitHubInstance{
@@ -48,6 +58,42 @@ func TestVerifyReleaseAsset(t *testing.T) {
 
 	assert.Equal(t, SAMPLE_RELEASE_ASSET_CHECKSUM_SHA256, checksumSha256, "SHA256 checksum of sample asset failed to match.")
 	assert.Equal(t, SAMPLE_RELEASE_ASSET_CHECKSUM_SHA512, checksumSha512, "SHA512 checksum of sample asset failed to match.")
+}
+
+func TestVerifyChecksumOfReleaseAsset(t *testing.T) {
+	tmpDir := mkTempDir(t)
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
+	githubRepo, err := ParseUrlIntoGitHubRepo(SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL, "", testInst)
+	if err != nil {
+		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
+	}
+
+	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_REGEX, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	if fetchErr != nil {
+		t.Fatalf("Failed to download release asset: %s", fetchErr)
+	}
+
+	if len(assetPaths) != 2 {
+		t.Fatalf("Incorrect number of release assets: %d", len(assetPaths))
+	}
+
+	for _, assetPath := range assetPaths {
+		checksumErr := verifyChecksumOfReleaseAsset(assetPath, SAMPLE_RELEASE_ASSET_CHECKSUMS_SHA256, "sha256")
+		if checksumErr != nil {
+			t.Fatalf("Expected downloaded asset to match one of %d checksums: %s", len(SAMPLE_RELEASE_ASSET_CHECKSUMS_SHA256), checksumErr)
+		}
+	}
+
+	for _, assetPath := range assetPaths {
+		checksumErr := verifyChecksumOfReleaseAsset(assetPath, SAMPLE_RELEASE_ASSET_CHECKSUMS_SHA256_NO_MATCH, "sha256")
+		if checksumErr == nil {
+			t.Fatalf("Expected downloaded asset to not match any checksums")
+		}
+	}
 }
 
 func mkTempDir(t *testing.T) string {

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -33,7 +33,7 @@ func TestVerifyReleaseAsset(t *testing.T) {
 	}
 
 	if len(assetPaths) != 1 {
-		t.Fatalf("Incorrect number of release assets: %s", len(assetPaths))
+		t.Fatalf("Incorrect number of release assets: %d", len(assetPaths))
 	}
 
 	checksumSha256, fetchErr := computeChecksum(assetPaths[0], "sha256")

--- a/github.go
+++ b/github.go
@@ -55,10 +55,10 @@ type GitHubTagsCommitApiResponse struct {
 // Modeled directly after the api.github.com response (but only includes the fields we care about). For more info, see:
 // https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
 type GitHubReleaseApiResponse struct {
-	Id      int
-	Url     string
-	Name    string
-	Assets  []GitHubReleaseAsset
+	Id     int
+	Url    string
+	Name   string
+	Assets []GitHubReleaseAsset
 }
 
 // The "assets" portion of the GitHubReleaseApiResponse. Modeled directly after the api.github.com response (but only
@@ -227,7 +227,7 @@ func callGitHubApi(repo GitHubRepo, path string, customHeaders map[string]string
 // Write the body of the given HTTP response to disk at the given path
 func writeResonseToDisk(resp *http.Response, destPath string) *FetchError {
 	out, err := os.Create(destPath)
-	if err != nil  {
+	if err != nil {
 		return wrapError(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -335,8 +335,8 @@ func findAssetsInRelease(assetRegex string, release GitHubReleaseApiResponse) ([
 	for _, asset := range release.Assets {
 		matched := pattern.MatchString(asset.Name)
 		if matched {
-			fmt.Printf("Found asset: %s\n", asset.Name)
-			matches = append(matches, &asset)
+			assetRef := asset
+			matches = append(matches, &assetRef)
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"testing"
 )
 
@@ -28,6 +30,14 @@ func TestDownloadReleaseAssets(t *testing.T) {
 
 	if len(assetPaths) != 2 {
 		t.Fatalf("Expected to download 2 assets, not %d", len(assetPaths))
+	}
+
+	for _, assetPath := range assetPaths {
+		if _, err := os.Stat(assetPath); os.IsNotExist(err) {
+			t.Fatalf("Downloaded file should exist at %s", assetPath)
+		} else {
+			fmt.Printf("Verified the downloaded asset exists at %s\n", assetPath)
+		}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+)
+
+// Expect to download 2 assets:
+// - health-checker_linux_386
+// - health-checker_linux_amd64
+const SAMPLE_RELEASE_ASSET_REGEX = "health-checker_linux_[a-z0-9]+"
+
+func TestDownloadReleaseAssets(t *testing.T) {
+	tmpDir := mkTempDir(t)
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
+	githubRepo, err := ParseUrlIntoGitHubRepo(SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL, "", testInst)
+	if err != nil {
+		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
+	}
+
+	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_REGEX, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	if fetchErr != nil {
+		t.Fatalf("Failed to download release asset: %s", fetchErr)
+	}
+
+	if len(assetPaths) != 2 {
+		t.Fatalf("Expected to download 2 assets, not %d", len(assetPaths))
+	}
+}
+
+func TestInvalidReleaseAssetsRegex(t *testing.T) {
+	tmpDir := mkTempDir(t)
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
+	githubRepo, err := ParseUrlIntoGitHubRepo(SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL, "", testInst)
+	if err != nil {
+		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
+	}
+
+	_, fetchErr := downloadReleaseAssets("*", tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	if fetchErr == nil {
+		t.Fatalf("Expected error for invalid regex")
+	}
+}


### PR DESCRIPTION
~**Caveat**: The checksum functionality for verifying release assets still only supports 1 asset. If multiple assets match the regex provided, an error will be returned.~

Multiple checksums can now be passed via the command line and the downloaded assets must match one of them.