### PR TITLE
Enable asset downloads from GitHub Enterprise

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,19 +2,51 @@
 
 
 [[projects]]
-  name = "github.com/codegangsta/cli"
-  packages = ["."]
-  revision = "71f57d300dd6a780ac1856c005c4b518cfd498ec"
-  version = "v1.14.0"
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
+  digest = "1:7398a6dcdc9283fdbd3ee279c7b80fa81e7ad9d6f9e71bc8e6394810870cc54d"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
+  pruneopts = ""
   revision = "2e7f5ea8e27bb3fdf9baa0881d16757ac4637332"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = ""
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:e85837cb04b78f61688c6eba93ea9d14f60d611e2aaf8319999b1a60d2dafbfa"
+  name = "gopkg.in/urfave/cli.v1"
+  packages = ["."]
+  pruneopts = ""
+  revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
+  version = "v1.20.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1cddc558a1d7a96f9a023c09dcc0753da855e8396aea95b14dc388c4c96c515d"
+  input-imports = [
+    "github.com/hashicorp/go-version",
+    "github.com/stretchr/testify/assert",
+    "gopkg.in/urfave/cli.v1",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/file.go
+++ b/file.go
@@ -14,7 +14,7 @@ import (
 // Download the zip file at the given URL to a temporary local directory.
 // Returns the absolute path to the downloaded zip file.
 // IMPORTANT: You must call "defer os.RemoveAll(dir)" in the calling function when done with the downloaded zip file!
-func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string) (string, *FetchError) {
+func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance) (string, *FetchError) {
 
 	var zipFilePath string
 
@@ -28,7 +28,7 @@ func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string) (strin
 
 	// Download the zip file, possibly using the GitHub oAuth Token
 	httpClient := &http.Client{}
-	req, err := MakeGitHubZipFileRequest(gitHubCommit, gitHubToken)
+	req, err := MakeGitHubZipFileRequest(gitHubCommit, gitHubToken, instance)
 	if err != nil {
 		return zipFilePath, wrapError(err)
 	}
@@ -114,7 +114,7 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string) erro
 
 // Return an HTTP request that will fetch the given GitHub repo's zip file for the given tag, possibly with the gitHubOAuthToken in the header
 // Respects the GitHubCommit hierachy as defined in the code comments for GitHubCommit (e.g. GitTag > CommitSha)
-func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string) (*http.Request, error) {
+func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance) (*http.Request, error) {
 	var request *http.Request
 
 	// This represents either a commit, branch, or git tag

--- a/file.go
+++ b/file.go
@@ -46,7 +46,11 @@ func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instan
 
 	// Copy the contents of the downloaded file to our empty file
 	respBodyBuffer := new(bytes.Buffer)
-	respBodyBuffer.ReadFrom(resp.Body)
+	_, err = respBodyBuffer.ReadFrom(resp.Body)
+	if err != nil {
+		return zipFilePath, wrapError(err)
+	}
+
 	err = ioutil.WriteFile(filepath.Join(tempDir, "repo.zip"), respBodyBuffer.Bytes(), 0644)
 	if err != nil {
 		return zipFilePath, wrapError(err)
@@ -87,7 +91,11 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string) erro
 
 			if f.FileInfo().IsDir() {
 				// Create a directory
-				os.MkdirAll(filepath.Join(localPath, strings.TrimPrefix(f.Name, pathPrefix)), 0777)
+				path := filepath.Join(localPath, strings.TrimPrefix(f.Name, pathPrefix))
+				err = os.MkdirAll(path, 0777)
+				if err != nil {
+					return fmt.Errorf("Failed to create local directory %s: %s", path, err)
+				}
 			} else {
 				// Read the file into a byte array
 				readCloser, err := f.Open()

--- a/file.go
+++ b/file.go
@@ -129,7 +129,13 @@ func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, ins
 		return request, fmt.Errorf("Neither a GitCommitSha nor a GitTag nor a BranchName were specified so impossible to identify a specific commit to download.")
 	}
 
-	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/zipball/%s", gitHubCommit.Repo.Owner, gitHubCommit.Repo.Name, gitRef)
+	var url string
+	if instance.ApiUrl != "api.github.com" {
+		url = fmt.Sprintf("https://"+instance.ApiUrl+"/repos/%s/%s/zipball/%s", gitHubCommit.Repo.Owner, gitHubCommit.Repo.Name, gitRef)
+	} else {
+		url = fmt.Sprintf("https://api.github.com/repos/%s/%s/zipball/%s", gitHubCommit.Repo.Owner, gitHubCommit.Repo.Name, gitRef)
+	}
+
 
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/file.go
+++ b/file.go
@@ -137,13 +137,7 @@ func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, ins
 		return request, fmt.Errorf("Neither a GitCommitSha nor a GitTag nor a BranchName were specified so impossible to identify a specific commit to download.")
 	}
 
-	var url string
-	if instance.ApiUrl != "api.github.com" {
-		url = fmt.Sprintf("https://"+instance.ApiUrl+"/repos/%s/%s/zipball/%s", gitHubCommit.Repo.Owner, gitHubCommit.Repo.Name, gitRef)
-	} else {
-		url = fmt.Sprintf("https://api.github.com/repos/%s/%s/zipball/%s", gitHubCommit.Repo.Owner, gitHubCommit.Repo.Name, gitRef)
-	}
-
+	url := fmt.Sprintf("https://%s/repos/%s/%s/zipball/%s", instance.ApiUrl, gitHubCommit.Repo.Owner, gitHubCommit.Repo.Name, gitRef)
 
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/file_test.go
+++ b/file_test.go
@@ -70,7 +70,7 @@ func TestDownloadGitTagZipFile(t *testing.T) {
 		if err != nil && strings.Contains(err.Error(), "no such host") {
 			if strings.Contains(err.Error(), githubEnterpriseDownloadUrl) {
 				t.Logf("Found expected download URL %s. Download itself failed as expected because no GitHub Enterprise instance exists at the given URL.", githubEnterpriseDownloadUrl)
-				t.SkipNow()
+				return
 			} else {
 				t.Fatalf("Attempted to download from URL other than the expected download URL of %s. Full error: %s", githubEnterpriseDownloadUrl, err.Error())
 			}

--- a/file_test.go
+++ b/file_test.go
@@ -21,14 +21,20 @@ func init() {
 func TestDownloadGitTagZipFile(t *testing.T) {
 	t.Parallel()
 
+	publicGitHub := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
 	cases := []struct {
+		instance 	GitHubInstance
 		repoOwner   string
 		repoName    string
 		gitTag      string
 		githubToken string
 	}{
-		{"gruntwork-io", "fetch-test-public", "v0.0.1", ""},
-		{"gruntwork-io", "fetch-test-private", "v0.0.2", os.Getenv("GITHUB_OAUTH_TOKEN")},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "v0.0.1", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-private", "v0.0.2", os.Getenv("GITHUB_OAUTH_TOKEN")},
 	}
 
 	for _, tc := range cases {
@@ -40,7 +46,7 @@ func TestDownloadGitTagZipFile(t *testing.T) {
 			GitTag: tc.gitTag,
 		}
 
-		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken)
+		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken, tc.instance)
 		defer os.RemoveAll(zipFilePath)
 		if err != nil {
 			t.Fatalf("Failed to download file: %s", err)
@@ -55,14 +61,20 @@ func TestDownloadGitTagZipFile(t *testing.T) {
 func TestDownloadGitBranchZipFile(t *testing.T) {
 	t.Parallel()
 
+	publicGitHub := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
 	cases := []struct {
+		instance 	GitHubInstance
 		repoOwner   string
 		repoName    string
 		branchName  string
 		githubToken string
 	}{
-		{"gruntwork-io", "fetch-test-public", "sample-branch", ""},
-		{"gruntwork-io", "fetch-test-private", "sample-branch", os.Getenv("GITHUB_OAUTH_TOKEN")},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "sample-branch", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-private", "sample-branch", os.Getenv("GITHUB_OAUTH_TOKEN")},
 	}
 
 	for _, tc := range cases {
@@ -74,7 +86,7 @@ func TestDownloadGitBranchZipFile(t *testing.T) {
 			BranchName: tc.branchName,
 		}
 
-		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken)
+		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken, tc.instance)
 		defer os.RemoveAll(zipFilePath)
 		if err != nil {
 			t.Fatalf("Failed to download file: %s", err)
@@ -89,13 +101,19 @@ func TestDownloadGitBranchZipFile(t *testing.T) {
 func TestDownloadBadGitBranchZipFile(t *testing.T) {
 	t.Parallel()
 
+	publicGitHub := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
 	cases := []struct {
+		instance 	GitHubInstance
 		repoOwner   string
 		repoName    string
 		branchName  string
 		githubToken string
 	}{
-		{"gruntwork-io", "fetch-test-public", "branch-that-doesnt-exist", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "branch-that-doesnt-exist", ""},
 	}
 
 	for _, tc := range cases {
@@ -107,7 +125,7 @@ func TestDownloadBadGitBranchZipFile(t *testing.T) {
 			BranchName: tc.branchName,
 		}
 
-		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken)
+		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken, tc.instance)
 		defer os.RemoveAll(zipFilePath)
 		if err == nil {
 			t.Fatalf("Expected that attempt to download repo %s/%s for branch \"%s\" would fail, but received no error.", tc.repoOwner, tc.repoName, tc.branchName)
@@ -118,16 +136,22 @@ func TestDownloadBadGitBranchZipFile(t *testing.T) {
 func TestDownloadGitCommitFile(t *testing.T) {
 	t.Parallel()
 
+	publicGitHub := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
 	cases := []struct {
+		instance 	GitHubInstance
 		repoOwner   string
 		repoName    string
 		commitSha   string
 		githubToken string
 	}{
-		{"gruntwork-io", "fetch-test-public", "d2de34edb4c6564e0674b3f390b3b1fb0468183a", ""},
-		{"gruntwork-io", "fetch-test-public", "57752e7f1df0acbd3c1e61545d5c4d0e87699d84", ""},
-		{"gruntwork-io", "fetch-test-public", "f32a08313e30f116a1f5617b8b68c11f1c1dbb61", ""},
-		{"gruntwork-io", "fetch-test-private", "676cfb92b54d33538c756c7a9479bfc3f6b44de2", os.Getenv("GITHUB_OAUTH_TOKEN")},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "d2de34edb4c6564e0674b3f390b3b1fb0468183a", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "57752e7f1df0acbd3c1e61545d5c4d0e87699d84", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "f32a08313e30f116a1f5617b8b68c11f1c1dbb61", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-private", "676cfb92b54d33538c756c7a9479bfc3f6b44de2", os.Getenv("GITHUB_OAUTH_TOKEN")},
 	}
 
 	for _, tc := range cases {
@@ -139,7 +163,7 @@ func TestDownloadGitCommitFile(t *testing.T) {
 			CommitSha: tc.commitSha,
 		}
 
-		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken)
+		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken, tc.instance)
 		defer os.RemoveAll(zipFilePath)
 		if err != nil {
 			t.Fatalf("Failed to download file: %s", err)
@@ -154,18 +178,24 @@ func TestDownloadGitCommitFile(t *testing.T) {
 func TestDownloadBadGitCommitFile(t *testing.T) {
 	t.Parallel()
 
+	publicGitHub := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
 	cases := []struct {
+		instance 	GitHubInstance
 		repoOwner   string
 		repoName    string
 		commitSha   string
 		githubToken string
 	}{
-		{"gruntwork-io", "fetch-test-public", "hello-world", ""},
-		{"gruntwork-io", "fetch-test-public", "i-am-a-non-existent-commit", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "hello-world", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "i-am-a-non-existent-commit", ""},
 		// remove a single letter from the beginning of an otherwise legit commit sha
 		// interestingly, through testing I found that GitHub will attempt to find the right commit sha if you
 		// truncate the end of it.
-		{"gruntwork-io", "fetch-test-public", "7752e7f1df0acbd3c1e61545d5c4d0e87699d84", ""},
+		{publicGitHub, "gruntwork-io", "fetch-test-public", "7752e7f1df0acbd3c1e61545d5c4d0e87699d84", ""},
 	}
 
 	for _, tc := range cases {
@@ -177,7 +207,7 @@ func TestDownloadBadGitCommitFile(t *testing.T) {
 			CommitSha: tc.commitSha,
 		}
 
-		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken)
+		zipFilePath, err := downloadGithubZipFile(gitHubCommit, tc.githubToken, tc.instance)
 		defer os.RemoveAll(zipFilePath)
 		if err == nil {
 			t.Fatalf("Expected that attempt to download repo %s/%s at commmit sha \"%s\" would fail, but received no error.", tc.repoOwner, tc.repoName, tc.commitSha)
@@ -188,13 +218,19 @@ func TestDownloadBadGitCommitFile(t *testing.T) {
 func TestDownloadZipFileWithBadRepoValues(t *testing.T) {
 	t.Parallel()
 
+	publicGitHub := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
 	cases := []struct {
+		instance 	GitHubInstance
 		repoOwner   string
 		repoName    string
 		gitTag      string
 		githubToken string
 	}{
-		{"https://github.com/gruntwork-io/fetch-test-public/archive/does-not-exist.zip", "MyNameIsWhat", "x.y.z", ""},
+		{publicGitHub, "https://github.com/gruntwork-io/fetch-test-public/archive/does-not-exist.zip", "MyNameIsWhat", "x.y.z", ""},
 	}
 
 	for _, tc := range cases {
@@ -206,7 +242,7 @@ func TestDownloadZipFileWithBadRepoValues(t *testing.T) {
 			GitTag: tc.gitTag,
 		}
 
-		_, err := downloadGithubZipFile(gitHubCommit, tc.githubToken)
+		_, err := downloadGithubZipFile(gitHubCommit, tc.githubToken, tc.instance)
 		if err == nil && err.errorCode != 500 {
 			t.Fatalf("Expected error for bad repo values: %s/%s:%s", tc.repoOwner, tc.repoName, tc.gitTag)
 		}
@@ -216,16 +252,22 @@ func TestDownloadZipFileWithBadRepoValues(t *testing.T) {
 func TestExtractFiles(t *testing.T) {
 	t.Parallel()
 
+	publicGitHub := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
 	cases := []struct {
+		instance 		  GitHubInstance
 		localFilePath     string
 		filePathToExtract string
 		expectedNumFiles  int
 		nonemptyFiles     []string
 	}{
-		{"test-fixtures/fetch-test-public-0.0.1.zip", "/", 1, nil},
-		{"test-fixtures/fetch-test-public-0.0.2.zip", "/", 2, nil},
-		{"test-fixtures/fetch-test-public-0.0.3.zip", "/", 4, []string{"/README.md"} },
-		{"test-fixtures/fetch-test-public-0.0.3.zip", "/folder", 2, nil},
+		{publicGitHub, "test-fixtures/fetch-test-public-0.0.1.zip", "/", 1, nil},
+		{publicGitHub, "test-fixtures/fetch-test-public-0.0.2.zip", "/", 2, nil},
+		{publicGitHub, "test-fixtures/fetch-test-public-0.0.3.zip", "/", 4, []string{"/README.md"} },
+		{publicGitHub, "test-fixtures/fetch-test-public-0.0.3.zip", "/folder", 2, nil},
 	}
 
 	for _, tc := range cases {

--- a/file_test.go
+++ b/file_test.go
@@ -61,7 +61,6 @@ func TestDownloadGitTagZipFile(t *testing.T) {
 		// will fail.
 
 		githubEnterpriseDownloadUrl := fmt.Sprintf("https://%s/repos/%s/%s/zipball/%s", tc.instance.ApiUrl, tc.repoOwner, tc.repoName, tc.gitTag)
-		githubEnterpriseErrorMessage := fmt.Sprintf("Get %s: dial tcp: lookup %s: no such host", githubEnterpriseDownloadUrl, tc.instance.BaseUrl)
 
 		// TODO: The awkwardness of this test makes it clear that a better structure for this program would be to refactor
 		// the downloadGithubZipFile() function to a function called downloadGithubFile() that would accept a URL as a
@@ -69,7 +68,7 @@ func TestDownloadGitTagZipFile(t *testing.T) {
 		// simpler to handle.
 
 		if err != nil && strings.Contains(err.Error(), "no such host") {
-			if strings.Contains(err.Error(), githubEnterpriseErrorMessage) {
+			if strings.Contains(err.Error(), githubEnterpriseDownloadUrl) {
 				t.Logf("Found expected download URL %s. Download itself failed as expected because no GitHub Enterprise instance exists at the given URL.", githubEnterpriseDownloadUrl)
 				t.SkipNow()
 			} else {

--- a/file_test.go
+++ b/file_test.go
@@ -60,21 +60,20 @@ func TestDownloadGitTagZipFile(t *testing.T) {
 		// so this test will only validate that fetch attempted to download from the expected URL. The download itself
 		// will fail.
 
-		githubEnterpriseDownloadUrl := fmt.Sprintf("https://%s/reposss/%s/%s/zipball/%s", tc.instance.ApiUrl, tc.repoOwner, tc.repoName, tc.gitTag)
+		githubEnterpriseDownloadUrl := fmt.Sprintf("https://%s/repos/%s/%s/zipball/%s", tc.instance.ApiUrl, tc.repoOwner, tc.repoName, tc.gitTag)
 		githubEnterpriseErrorMessage := fmt.Sprintf("Get %s: dial tcp: lookup %s: no such host", githubEnterpriseDownloadUrl, tc.instance.BaseUrl)
 
-		fmt.Printf("Expected error message: %s\n", githubEnterpriseErrorMessage)
-
-		if err != nil {
-			fmt.Printf("Actual error message: %s\n", err.Error())
-		}
+		// TODO: The awkwardness of this test makes it clear that a better structure for this program would be to refactor
+		// the downloadGithubZipFile() function to a function called downloadGithubFile() that would accept a URL as a
+		// param. We could then test explicitly that the URL is as expected, which would make GitHub Enterprise test cases
+		// simpler to handle.
 
 		if err != nil && strings.Contains(err.Error(), "no such host") {
 			if strings.Contains(err.Error(), githubEnterpriseErrorMessage) {
 				t.Logf("Found expected download URL %s. Download itself failed as expected because no GitHub Enterprise instance exists at the given URL.", githubEnterpriseDownloadUrl)
 				t.SkipNow()
 			} else {
-				t.Fatalf("Attempted to download from URL other than the expected download URL of %s", githubEnterpriseDownloadUrl)
+				t.Fatalf("Attempted to download from URL other than the expected download URL of %s. Full error: %s", githubEnterpriseDownloadUrl, err.Error())
 			}
 		}
 

--- a/github.go
+++ b/github.go
@@ -110,7 +110,10 @@ func FetchTags(githubRepoUrl string, githubToken string, instance GitHubInstance
 
 	// Convert the response body to a byte array
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
+	_, goErr := buf.ReadFrom(resp.Body)
+	if goErr != nil {
+		return tagsString, wrapError(goErr)
+	}
 	jsonResp := buf.Bytes()
 
 	// Extract the JSON into our array of gitHubTagsCommitApiResponse's
@@ -175,7 +178,10 @@ func GetGitHubReleaseInfo(repo GitHubRepo, tag string) (GitHubReleaseApiResponse
 
 	// Convert the response body to a byte array
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
+	_, goErr := buf.ReadFrom(resp.Body)
+	if goErr != nil {
+		return release, wrapError(goErr)
+	}
 	jsonResp := buf.Bytes()
 
 	if err := json.Unmarshal(jsonResp, &release); err != nil {
@@ -208,13 +214,18 @@ func callGitHubApi(repo GitHubRepo, path string, customHeaders map[string]string
 	}
 
 	resp, err := httpClient.Do(request)
+
 	if err != nil {
 		return nil, wrapError(err)
 	}
+
 	if resp.StatusCode != 200 {
 		// Convert the resp.Body to a string
 		buf := new(bytes.Buffer)
-		buf.ReadFrom(resp.Body)
+		_, goErr := buf.ReadFrom(resp.Body)
+		if goErr != nil {
+			return nil, wrapError(goErr)
+		}
 		respBody := buf.String()
 
 		// We leverage the HTTP Response Code as our ErrorCode here.

--- a/github_test.go
+++ b/github_test.go
@@ -42,8 +42,8 @@ func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 			t.Fatalf("expected non-empty list of releases for repo %s, but no releases were found", tc.repoUrl)
 		}
 
-		if releases[len(releases) - 1] != tc.firstReleaseTag {
-			t.Fatalf("error parsing github releases for repo %s. expected first release = %s, actual = %s", tc.repoUrl, tc.firstReleaseTag, releases[len(releases) - 1])
+		if releases[len(releases)-1] != tc.firstReleaseTag {
+			t.Fatalf("error parsing github releases for repo %s. expected first release = %s, actual = %s", tc.repoUrl, tc.firstReleaseTag, releases[len(releases)-1])
 		}
 
 		if releases[0] != tc.lastReleaseTag {
@@ -208,22 +208,22 @@ func TestGetGitHubReleaseInfo(t *testing.T) {
 	token := os.Getenv("GITHUB_OAUTH_TOKEN")
 
 	expectedFetchTestPrivateRelease := GitHubReleaseApiResponse{
-		Id: 3064041,
-		Url: "https://api.github.com/repos/gruntwork-io/fetch-test-private/releases/3064041",
+		Id:   3064041,
+		Url:  "https://api.github.com/repos/gruntwork-io/fetch-test-private/releases/3064041",
 		Name: "v0.0.2",
 		Assets: []GitHubReleaseAsset{
 			{
-				Id: 1872521,
-				Url: "https://api.github.com/repos/gruntwork-io/fetch-test-private/releases/assets/1872521",
+				Id:   1872521,
+				Url:  "https://api.github.com/repos/gruntwork-io/fetch-test-private/releases/assets/1872521",
 				Name: "test-asset.png",
 			},
 		},
 	}
 
 	expectedFetchTestPublicRelease := GitHubReleaseApiResponse{
-		Id: 3065803,
-		Url: "https://api.github.com/repos/gruntwork-io/fetch-test-public/releases/3065803",
-		Name: "v0.0.3",
+		Id:     3065803,
+		Url:    "https://api.github.com/repos/gruntwork-io/fetch-test-public/releases/3065803",
+		Name:   "v0.0.3",
 		Assets: []GitHubReleaseAsset{},
 	}
 
@@ -259,7 +259,7 @@ func TestGetGitHubReleaseInfo(t *testing.T) {
 	}
 }
 
-func TestDownloadReleaseAsset(t *testing.T) {
+func TestDownloadGitHubPulicReleaseAsset(t *testing.T) {
 	t.Parallel()
 
 	token := os.Getenv("GITHUB_OAUTH_TOKEN")
@@ -277,7 +277,6 @@ func TestDownloadReleaseAsset(t *testing.T) {
 	}{
 		{"https://github.com/gruntwork-io/fetch-test-private", token, "v0.0.2", 1872521},
 		{"https://github.com/gruntwork-io/fetch-test-public", "", "v0.0.2", 1872641},
-		{"https://github-enterpise.acme.com/org1/bash-commons", "", "v0.0.4", -1},
 	}
 
 	for _, tc := range cases {

--- a/github_test.go
+++ b/github_test.go
@@ -277,6 +277,7 @@ func TestDownloadReleaseAsset(t *testing.T) {
 	}{
 		{"https://github.com/gruntwork-io/fetch-test-private", token, "v0.0.2", 1872521},
 		{"https://github.com/gruntwork-io/fetch-test-public", "", "v0.0.2", 1872641},
+		{"https://github-enterpise.acme.com/org1/bash-commons", "", "v0.0.4", -1},
 	}
 
 	for _, tc := range cases {

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func runFetch(c *cli.Context) error {
 	}
 
 	// Download any requested source files
-	if err := downloadSourcePaths(options.SourcePaths, options.LocalDownloadPath, repo, desiredTag, options.BranchName, options.CommitSha); err != nil {
+	if err := downloadSourcePaths(options.SourcePaths, options.LocalDownloadPath, repo, desiredTag, options.BranchName, options.CommitSha, instance); err != nil {
 		return err
 	}
 
@@ -246,7 +246,7 @@ func validateOptions(options FetchOptions) error {
 }
 
 // Download the specified source files from the given repo
-func downloadSourcePaths(sourcePaths []string, destPath string, githubRepo GitHubRepo, latestTag string, branchName string, commitSha string) error {
+func downloadSourcePaths(sourcePaths []string, destPath string, githubRepo GitHubRepo, latestTag string, branchName string, commitSha string, instance GitHubInstance) error {
 	if len(sourcePaths) == 0 {
 		return nil
 	}
@@ -273,7 +273,7 @@ func downloadSourcePaths(sourcePaths []string, destPath string, githubRepo GitHu
 		return fmt.Errorf("The commit sha, tag, and branch name are all empty.")
 	}
 
-	localZipFilePath, err := downloadGithubZipFile(gitHubCommit, githubRepo.Token)
+	localZipFilePath, err := downloadGithubZipFile(gitHubCommit, githubRepo.Token, instance)
 	if err != nil {
 		return fmt.Errorf("Error occurred while downloading zip file from GitHub repo: %s", err)
 	}


### PR DESCRIPTION
Fixes #48. This is a tricky one to test because we don't have a running instance of GitHub Enterprise against which we can run integration tests. So the best we can do is to validate that the URL fetch attempts to download from in the case of GitHub Enterprise is as expected.

I also noticed a few areas where errors were being swallowed so I added some boilerplate error handling code for those cases. 

In the end, for the +178 lines of code additions here, the actual bug fix just 4 lines of code.