### PR TITLE
Add progress to file download

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,6 +10,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:f1a75a8e00244e5ea77ff274baa9559eb877437b240ee7b278f3fc560d9f08bf"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  pruneopts = ""
+  revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:7398a6dcdc9283fdbd3ee279c7b80fa81e7ad9d6f9e71bc8e6394810870cc54d"
   name = "github.com/hashicorp/go-version"
   packages = ["."]
@@ -44,6 +52,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/dustin/go-humanize",
     "github.com/hashicorp/go-version",
     "github.com/stretchr/testify/assert",
     "gopkg.in/urfave/cli.v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,3 +26,7 @@
 
 [[constraint]]
   name = "github.com/hashicorp/go-version"
+
+[[constraint]]
+  name = "github.com/dustin/go-humanize"
+  version = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The supported options are:
   saved in bash history.
 - `--github-api-version` (**Optional**): Used when fetching an artifact from a GitHub Enterprise instance.
   Defaults to `v3`. This is ignored when fetching from GitHub.com.
+- `--progress` (**Optional**): Used when fetching a big file and want to see progress on the fetch.
 
 The supported arguments are:
 

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -37,7 +37,7 @@ func TestVerifyReleaseAsset(t *testing.T) {
 		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
 	}
 
-	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_NAME, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_NAME, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION, false)
 	if fetchErr != nil {
 		t.Fatalf("Failed to download release asset: %s", fetchErr)
 	}
@@ -72,7 +72,7 @@ func TestVerifyChecksumOfReleaseAsset(t *testing.T) {
 		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
 	}
 
-	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_REGEX, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_REGEX, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION, false)
 	if fetchErr != nil {
 		t.Fatalf("Failed to download release asset: %s", fetchErr)
 	}

--- a/github_test.go
+++ b/github_test.go
@@ -274,9 +274,11 @@ func TestDownloadGitHubPulicReleaseAsset(t *testing.T) {
 		repoToken string
 		tag       string
 		assetId   int
+		progress  bool
 	}{
-		{"https://github.com/gruntwork-io/fetch-test-private", token, "v0.0.2", 1872521},
-		{"https://github.com/gruntwork-io/fetch-test-public", "", "v0.0.2", 1872641},
+		{"https://github.com/gruntwork-io/fetch-test-private", token, "v0.0.2", 1872521, false},
+		{"https://github.com/gruntwork-io/fetch-test-public", "", "v0.0.2", 1872641, false},
+		{"https://github.com/gruntwork-io/fetch-test-public", "", "v0.0.2", 1872641, true},
 	}
 
 	for _, tc := range cases {
@@ -290,7 +292,7 @@ func TestDownloadGitHubPulicReleaseAsset(t *testing.T) {
 			t.Fatalf("Failed to create temp file due to error: %s", tmpErr.Error())
 		}
 
-		if err := DownloadReleaseAsset(repo, tc.assetId, tmpFile.Name()); err != nil {
+		if err := DownloadReleaseAsset(repo, tc.assetId, tmpFile.Name(), tc.progress); err != nil {
 			t.Fatalf("Failed to download asset %d to %s from GitHub URL %s due to error: %s", tc.assetId, tmpFile.Name(), tc.repoUrl, err.Error())
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -25,7 +25,7 @@ func TestDownloadReleaseAssets(t *testing.T) {
 		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
 	}
 
-	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_REGEX, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	assetPaths, fetchErr := downloadReleaseAssets(SAMPLE_RELEASE_ASSET_REGEX, tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION, false)
 	if fetchErr != nil {
 		t.Fatalf("Failed to download release asset: %s", fetchErr)
 	}
@@ -55,7 +55,7 @@ func TestInvalidReleaseAssetsRegex(t *testing.T) {
 		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
 	}
 
-	_, fetchErr := downloadReleaseAssets("*", tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION)
+	_, fetchErr := downloadReleaseAssets("*", tmpDir, githubRepo, SAMPLE_RELEASE_ASSET_VERSION, false)
 	if fetchErr == nil {
 		t.Fatalf("Expected error for invalid regex")
 	}
@@ -97,6 +97,9 @@ func TestEmptyOptionValues(t *testing.T) {
 			Name:  OPTION_GITHUB_API_VERSION,
 			Value: "v3",
 		},
+		cli.StringFlag{
+			Name: OPTION_WITH_PROGRESS,
+		},
 	}
 
     app.Action = func(c *cli.Context) error {
@@ -119,6 +122,7 @@ func TestEmptyOptionValues(t *testing.T) {
         OPTION_RELEASE_ASSET_CHECKSUM,
         OPTION_RELEASE_ASSET_CHECKSUM_ALGO,
         OPTION_GITHUB_API_VERSION,
+        OPTION_WITH_PROGRESS,
     }
 
     for _, option := range optionsList {


### PR DESCRIPTION
This PR fixes issue issue https://github.com/gruntwork-io/fetch/issues/45

Progress on file download makes downloading large files much easier as feedback
is given once per second now.