### PR TITLE
Add CircleCi Context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ workflows:
             tags:
               only: /^v.*/
       - build:
+          context:
+            - Gruntwork Admin
           requires:
             - test
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,8 @@ workflows:
   build-and-test:
     jobs:
       - test:
+          context:
+            - Gruntwork Admin
           filters:
             tags:
               only: /^v.*/
@@ -44,6 +46,8 @@ workflows:
               only: /^v.*/
 
       - deploy:
+          context:
+            - Gruntwork Admin
           requires:
             - build
           filters:
@@ -61,4 +65,6 @@ workflows:
             branches:
               only: master
     jobs:
-      - test
+      - test:
+          context:
+            - Gruntwork Admin


### PR DESCRIPTION
This repo was using a custom set of credentials for Phx DevOps and our GitHub machine user. I've removed those creds from the CircleCi config and here am switching the repo to use [CircleCi Contexts](https://circleci.com/docs/2.0/contexts) instead.