### PR TITLE
Show file count on zip extraction

### DIFF
--- a/file.go
+++ b/file.go
@@ -117,24 +117,24 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string) (int
 				path := filepath.Join(localPath, strings.TrimPrefix(f.Name, pathPrefix))
 				err = os.MkdirAll(path, 0777)
 				if err != nil {
-					return 0, fmt.Errorf("Failed to create local directory %s: %s", path, err)
+					return fileCount, fmt.Errorf("Failed to create local directory %s: %s", path, err)
 				}
 			} else {
 				// Read the file into a byte array
 				readCloser, err := f.Open()
 				if err != nil {
-					return 0, fmt.Errorf("Failed to open file %s: %s", f.Name, err)
+					return fileCount, fmt.Errorf("Failed to open file %s: %s", f.Name, err)
 				}
 
 				byteArray, err := ioutil.ReadAll(readCloser)
 				if err != nil {
-					return 0, fmt.Errorf("Failed to read file %s: %s", f.Name, err)
+					return fileCount, fmt.Errorf("Failed to read file %s: %s", f.Name, err)
 				}
 
 				// Write the file
 				err = ioutil.WriteFile(filepath.Join(localPath, strings.TrimPrefix(f.Name, pathPrefix)), byteArray, 0644)
 				if err != nil {
-					return 0, fmt.Errorf("Failed to write file: %s", err)
+					return fileCount, fmt.Errorf("Failed to write file: %s", err)
 				}
 				fileCount++
 			}

--- a/file_test.go
+++ b/file_test.go
@@ -307,9 +307,13 @@ func TestExtractFiles(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		_, err = extractFiles(tc.localFilePath, tc.filePathToExtract, tempDir)
+		fileCount, err := extractFiles(tc.localFilePath, tc.filePathToExtract, tempDir)
 		if err != nil {
 			t.Fatalf("Failed to extract files: %s", err)
+		}
+
+		if fileCount != tc.expectedNumFiles {
+			t.Fatalf("Expected to extract %d files, extracted %d instead", tc.expectedNumFiles, fileCount)
 		}
 
 		// Count the number of files in the directory

--- a/file_test.go
+++ b/file_test.go
@@ -355,10 +355,16 @@ func TestExtractFilesExtractFile(t *testing.T) {
 	zipFilePath := "test-fixtures/fetch-test-public-0.0.4.zip"
 	filePathToExtract := "zzz.txt"
 	localFileName := "/localzzz.txt"
+	expectedFileCount := 1
 	localPathName := filepath.Join(tempDir, localFileName)
-	_, err = extractFiles(zipFilePath, filePathToExtract, localPathName)
+	fileCount, err := extractFiles(zipFilePath, filePathToExtract, localPathName)
+
 	if err != nil {
 		t.Fatalf("Failed to extract files: %s", err)
+	}
+
+	if fileCount != expectedFileCount {
+		t.Fatalf("Expected to extract %d files, extracted %d instead", expectedFileCount, fileCount)
 	}
 
 	filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {

--- a/file_test.go
+++ b/file_test.go
@@ -307,7 +307,7 @@ func TestExtractFiles(t *testing.T) {
 		}
 		defer os.RemoveAll(tempDir)
 
-		err = extractFiles(tc.localFilePath, tc.filePathToExtract, tempDir)
+		_, err = extractFiles(tc.localFilePath, tc.filePathToExtract, tempDir)
 		if err != nil {
 			t.Fatalf("Failed to extract files: %s", err)
 		}
@@ -352,7 +352,7 @@ func TestExtractFilesExtractFile(t *testing.T) {
 	filePathToExtract := "zzz.txt"
 	localFileName := "/localzzz.txt"
 	localPathName := filepath.Join(tempDir, localFileName)
-	err = extractFiles(zipFilePath, filePathToExtract, localPathName)
+	_, err = extractFiles(zipFilePath, filePathToExtract, localPathName)
 	if err != nil {
 		t.Fatalf("Failed to extract files: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -289,15 +289,14 @@ func downloadSourcePaths(sourcePaths []string, destPath string, githubRepo GitHu
 	// Unzip and move the files we need to our destination
 	for _, sourcePath := range sourcePaths {
 		fmt.Printf("Extracting files from <repo>%s to %s ... ", sourcePath, destPath)
-		if fileCount, err := extractFiles(localZipFilePath, sourcePath, destPath); err != nil {
-			fmt.Println()
+		fileCount, err := extractFiles(localZipFilePath, sourcePath, destPath)
+		plural := ""
+		if fileCount != 1 {
+			plural = "s"
+		}
+		fmt.Printf("%d file%s extracted\n", fileCount, plural)
+		if err != nil {
 			return fmt.Errorf("Error occurred while extracting files from GitHub zip file: %s", err.Error())
-		} else {
-			plural := ""
-			if fileCount != 1 {
-				plural = "s"
-			}
-			fmt.Printf("%d file%s extracted\n", fileCount, plural)
 		}
 
 	}

--- a/main.go
+++ b/main.go
@@ -288,10 +288,18 @@ func downloadSourcePaths(sourcePaths []string, destPath string, githubRepo GitHu
 
 	// Unzip and move the files we need to our destination
 	for _, sourcePath := range sourcePaths {
-		fmt.Printf("Extracting files from <repo>%s to %s ...\n", sourcePath, destPath)
-		if err := extractFiles(localZipFilePath, sourcePath, destPath); err != nil {
+		fmt.Printf("Extracting files from <repo>%s to %s ... ", sourcePath, destPath)
+		if fileCount, err := extractFiles(localZipFilePath, sourcePath, destPath); err != nil {
+			fmt.Println()
 			return fmt.Errorf("Error occurred while extracting files from GitHub zip file: %s", err.Error())
+		} else {
+			plural := ""
+			if fileCount != 1 {
+				plural = "s"
+			}
+			fmt.Printf("%d file%s extracted\n", fileCount, plural)
 		}
+
 	}
 
 	fmt.Println("Download and file extraction complete.")


### PR DESCRIPTION
This closes #39 

The route I took here was to just show the non-directory file count every time; if you'd prefer that I follow the letter of the issue and only print when the number of files is zero, I can make that change.

I also did a minor "look and feel" by pluralizing the wording, I think it's a nice touch, but it does add a bit of extra code (no ternary operator in golang), so I'm happy to change that if desired, too.