### PR TITLE
Skip tags that are not Semantically Versioned

### DIFF
--- a/github.go
+++ b/github.go
@@ -127,6 +127,7 @@ func FetchTags(githubRepoUrl string, githubToken string, instance GitHubInstance
 	}
 
 	for _, tag := range tags {
+		// Skip tags that are not semantically versioned so that they don't cause errors. (issue #75)
 		if _, err := version.NewVersion(tag.Name); err == nil {
 			tagsString = append(tagsString, tag.Name)
 		}

--- a/github.go
+++ b/github.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/dustin/go-humanize"
+	"github.com/hashicorp/go-version"
 )
 
 type GitHubRepo struct {
@@ -96,7 +97,7 @@ func ParseUrlIntoGithubInstance(repoUrl string, apiv string) (GitHubInstance, *F
 	return instance, nil
 }
 
-// Fetch all tags from the given GitHub repo
+// Fetch all SemVer tags from the given GitHub repo
 func FetchTags(githubRepoUrl string, githubToken string, instance GitHubInstance) ([]string, *FetchError) {
 	var tagsString []string
 
@@ -106,6 +107,7 @@ func FetchTags(githubRepoUrl string, githubToken string, instance GitHubInstance
 	}
 
 	url := createGitHubRepoUrlForPath(repo, "tags")
+
 	resp, err := callGitHubApi(repo, url, map[string]string{})
 	if err != nil {
 		return tagsString, err
@@ -126,7 +128,9 @@ func FetchTags(githubRepoUrl string, githubToken string, instance GitHubInstance
 	}
 
 	for _, tag := range tags {
-		tagsString = append(tagsString, tag.Name)
+		if _, err := version.NewVersion(tag.Name); err == nil {
+			tagsString = append(tagsString, tag.Name)
+		}
 	}
 
 	return tagsString, nil

--- a/github.go
+++ b/github.go
@@ -107,7 +107,6 @@ func FetchTags(githubRepoUrl string, githubToken string, instance GitHubInstance
 	}
 
 	url := createGitHubRepoUrlForPath(repo, "tags")
-
 	resp, err := callGitHubApi(repo, url, map[string]string{})
 	if err != nil {
 		return tagsString, err

--- a/github_test.go
+++ b/github_test.go
@@ -18,14 +18,15 @@ func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 		repoUrl          string
 		firstReleaseTag  string
 		lastReleaseTag   string
+		expectedNumTags  int
 		gitHubOAuthToken string
 		testInst         GitHubInstance
 	}{
 		// Test on a public repo whose sole purpose is to be a test fixture for this tool
-		{"https://github.com/gruntwork-io/fetch-test-public", "v0.0.1", "v0.0.3", "", testInst},
+		{"https://github.com/gruntwork-io/fetch-test-public", "v0.0.1", "v0.0.3", 3, "", testInst},
 
 		// Private repo equivalent
-		{"https://github.com/gruntwork-io/fetch-test-private", "v0.0.2", "v0.0.2", os.Getenv("GITHUB_OAUTH_TOKEN"), testInst},
+		{"https://github.com/gruntwork-io/fetch-test-private", "v0.0.2", "v0.0.2", 1, os.Getenv("GITHUB_OAUTH_TOKEN"), testInst},
 	}
 
 	for _, tc := range cases {
@@ -40,6 +41,10 @@ func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 
 		if len(releases) == 0 && tc.firstReleaseTag != "" {
 			t.Fatalf("expected non-empty list of releases for repo %s, but no releases were found", tc.repoUrl)
+		}
+
+		if len(releases) != tc.expectedNumTags {
+			t.Fatalf("expected %d releases, but got %d", tc.expectedNumTags, len(releases))
 		}
 
 		if releases[len(releases)-1] != tc.firstReleaseTag {


### PR DESCRIPTION
This closes #75 

I validated each tag, discarding any that aren't SemVer.

For testing, I suggest that a non-SemVer tag be added to the public and private test repositories `github_test.go`.

https://github.com/gruntwork-io/fetch/blob/4bec67f9ab28423e6b6f72b2fc9d397e5681c671/github_test.go#L25-L28 