### PR TITLE
Enable HTTP retries in fetch

### DIFF
--- a/file.go
+++ b/file.go
@@ -9,14 +9,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const retrySleepSeconds = 1;
 
 // Download the zip file at the given URL to a temporary local directory.
 // Returns the absolute path to the downloaded zip file.
 // IMPORTANT: You must call "defer os.RemoveAll(dir)" in the calling function when done with the downloaded zip file!
-func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance, retryNumber int) (string, *FetchError) {
+func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance, retries int) (string, *FetchError) {
 
 	var zipFilePath string
+	var resp http.Response
 
 	// Create a temp directory
 	// Note that ioutil.TempDir has a peculiar interface. We need not specify any meaningful values to achieve our
@@ -28,12 +32,21 @@ func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instan
 
 	// Download the zip file, possibly using the GitHub oAuth Token
 	httpClient := &http.Client{}
-	req, err := MakeGitHubZipFileRequest(gitHubCommit, gitHubToken, instance, retryNumber)
+	req, err := MakeGitHubZipFileRequest(gitHubCommit, gitHubToken, instance)
 	if err != nil {
 		return zipFilePath, wrapError(err)
 	}
 
-	resp, err := httpClient.Do(req)
+	for retries +=1; retries > 0; retries -= 1 {
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			fmt.Printf("Error encountered downloading from %s: %s; continuing", req, err)
+			time.Sleep(retrySleepSeconds * time.Second) // Effective linear backoff
+		}
+	}
+
+	// By the time we're here, we either have an error we deem permanent, or
+	// we've retried enough to succeed.
 	if err != nil {
 		return zipFilePath, wrapError(err)
 	}
@@ -146,7 +159,7 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string) (int
 
 // Return an HTTP request that will fetch the given GitHub repo's zip file for the given tag, possibly with the gitHubOAuthToken in the header
 // Respects the GitHubCommit hierachy as defined in the code comments for GitHubCommit (e.g. GitTag > CommitSha)
-func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance, retryNumber int) (*http.Request, error) {
+func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance) (*http.Request, error) {
 	var request *http.Request
 
 	// This represents either a commit, branch, or git tag

--- a/file.go
+++ b/file.go
@@ -14,7 +14,7 @@ import (
 // Download the zip file at the given URL to a temporary local directory.
 // Returns the absolute path to the downloaded zip file.
 // IMPORTANT: You must call "defer os.RemoveAll(dir)" in the calling function when done with the downloaded zip file!
-func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance) (string, *FetchError) {
+func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance, retryNumber int) (string, *FetchError) {
 
 	var zipFilePath string
 
@@ -28,7 +28,7 @@ func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instan
 
 	// Download the zip file, possibly using the GitHub oAuth Token
 	httpClient := &http.Client{}
-	req, err := MakeGitHubZipFileRequest(gitHubCommit, gitHubToken, instance)
+	req, err := MakeGitHubZipFileRequest(gitHubCommit, gitHubToken, instance, retryNumber)
 	if err != nil {
 		return zipFilePath, wrapError(err)
 	}
@@ -146,7 +146,7 @@ func extractFiles(zipFilePath, filesToExtractFromZipPath, localPath string) (int
 
 // Return an HTTP request that will fetch the given GitHub repo's zip file for the given tag, possibly with the gitHubOAuthToken in the header
 // Respects the GitHubCommit hierachy as defined in the code comments for GitHubCommit (e.g. GitTag > CommitSha)
-func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance) (*http.Request, error) {
+func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, instance GitHubInstance, retryNumber int) (*http.Request, error) {
 	var request *http.Request
 
 	// This represents either a commit, branch, or git tag

--- a/file.go
+++ b/file.go
@@ -34,7 +34,7 @@ func downloadGithubZipFile(gitHubCommit GitHubCommit, gitHubToken string, instan
 		return zipFilePath, wrapError(err)
 	}
 
-  resp, err = HttpDoWithRetry(httpClient, req, retries)
+	resp, err = HttpDoWithRetry(httpClient, req, retries)
 
 	if resp.StatusCode != http.StatusOK {
 		return zipFilePath, newError(failedToDownloadFile, fmt.Sprintf("Failed to download file at the url %s. Received HTTP Response %d.", req.URL.String(), resp.StatusCode))

--- a/github.go
+++ b/github.go
@@ -75,6 +75,8 @@ type GitHubReleaseAsset struct {
 	Name string
 }
 
+const retrySleepSeconds = 1 * time.Second;
+
 func ParseUrlIntoGithubInstance(repoUrl string, apiv string) (GitHubInstance, *FetchError) {
 	var instance GitHubInstance
 
@@ -203,11 +205,35 @@ func createGitHubRepoUrlForPath(repo GitHubRepo, path string) string {
 	return fmt.Sprintf("repos/%s/%s/%s", repo.Owner, repo.Name, path)
 }
 
+func HttpDoWithRetry(httpClient *http.Client, request *http.Request, retries int) (*http.Response, error) {
+	var err error
+	var resp *http.Response
+		// This looks slightly artificial, but if retries = 0, we never invoke the loop.
+		// Intuitively though the CLI retries is the number of times we _retry_ as opposed
+		// to try. There are alternative ways of structuring it, but we should probably
+		// just replace this with retryablehttp anyway.
+		for retries += 1; retries > 0; retries -= 1 {
+			resp, err := httpClient.Do(request)
+			if err != nil {
+				fmt.Printf("Error encountered downloading from %s: %s; continuing", request, err)
+				time.Sleep(retrySleepSeconds) // Effective linear backoff
+			} else {
+				retries = 0
+			}
+		}
+		// By the time we're here, we either have an error we deem permanent, or
+		// we've retried enough to succeed.
+		if err != nil {
+			return nil, wrapError(err)
+		}
+		return resp, err
+}
+
 // Call the GitHub API at the given path and return the HTTP response
 func callGitHubApi(repo GitHubRepo, path string, customHeaders map[string]string, retries int) (*http.Response, *FetchError) {
 	httpClient := &http.Client{}
 
-  var resp *http.Response
+	var resp *http.Response
 	var err error
 
 	request, err := http.NewRequest("GET", fmt.Sprintf("https://"+repo.ApiUrl+"/%s", path), nil)
@@ -223,23 +249,7 @@ func callGitHubApi(repo GitHubRepo, path string, customHeaders map[string]string
 		request.Header.Set(headerName, headerValue)
 	}
 
-	// This looks slightly artificial, but if retries = 0, we never invoke the loop,
-	// but intuitively on the CLI retries is the number of times we _retry_ as opposed
-	// to try. There are alternative ways of structuring it, but we should probably
-	// just replace this with retryablehttp anyway.
-
-	for retries +=1; retries > 0; retries -= 1 {
-		resp, err := httpClient.Do(request)
-		if err != nil {
-			fmt.Printf("Error encountered downloading from %s: %s; continuing", request, err)
-			time.Sleep(retrySleepSeconds * time.Second) // Effective linear backoff
-		}
-  }
-  // By the time we're here, we either have an error we deem permanent, or
-	// we've retried enough to succeed.
-	if err != nil {
-		return nil, wrapError(err)
-	}
+	resp, err = HttpDoWithRetry(httpClient, request, retries)
 
 	if resp.StatusCode != http.StatusOK {
 		// Convert the resp.Body to a string

--- a/github.go
+++ b/github.go
@@ -75,7 +75,7 @@ type GitHubReleaseAsset struct {
 	Name string
 }
 
-const retrySleepSeconds = 1 * time.Second;
+const retrySleepSeconds = 1 * time.Second
 
 func ParseUrlIntoGithubInstance(repoUrl string, apiv string) (GitHubInstance, *FetchError) {
 	var instance GitHubInstance
@@ -208,25 +208,25 @@ func createGitHubRepoUrlForPath(repo GitHubRepo, path string) string {
 func HttpDoWithRetry(httpClient *http.Client, request *http.Request, retries int) (*http.Response, error) {
 	var err error
 	var resp *http.Response
-		// This looks slightly artificial, but if retries = 0, we never invoke the loop.
-		// Intuitively though the CLI retries is the number of times we _retry_ as opposed
-		// to try. There are alternative ways of structuring it, but we should probably
-		// just replace this with retryablehttp anyway.
-		for retries += 1; retries > 0; retries -= 1 {
-			resp, err := httpClient.Do(request)
-			if err != nil {
-				fmt.Printf("Error encountered downloading from %s: %s; continuing", request, err)
-				time.Sleep(retrySleepSeconds) // Effective linear backoff
-			} else {
-				retries = 0
-			}
-		}
-		// By the time we're here, we either have an error we deem permanent, or
-		// we've retried enough to succeed.
+	// This looks slightly artificial, but if retries = 0, we never invoke the loop.
+	// Intuitively though the CLI retries is the number of times we _retry_ as opposed
+	// to try. There are alternative ways of structuring it, but we should probably
+	// just replace this with retryablehttp anyway.
+	for retries += 1; retries > 0; retries -= 1 {
+		resp, err := httpClient.Do(request)
 		if err != nil {
-			return nil, wrapError(err)
+			fmt.Printf("Error encountered downloading from %s: %s; continuing", request, err)
+			time.Sleep(retrySleepSeconds) // Effective linear backoff
+		} else {
+			retries = 0
 		}
-		return resp, err
+	}
+	// By the time we're here, we either have an error we deem permanent, or
+	// we've retried enough to succeed.
+	if err != nil {
+		return nil, wrapError(err)
+	}
+	return resp, err
 }
 
 // Call the GitHub API at the given path and return the HTTP response

--- a/github.go
+++ b/github.go
@@ -75,8 +75,6 @@ type GitHubReleaseAsset struct {
 	Name string
 }
 
-const retrySleepSeconds = 1;
-
 func ParseUrlIntoGithubInstance(repoUrl string, apiv string) (GitHubInstance, *FetchError) {
 	var instance GitHubInstance
 
@@ -234,7 +232,6 @@ func callGitHubApi(repo GitHubRepo, path string, customHeaders map[string]string
 		resp, err := httpClient.Do(request)
 		if err != nil {
 			fmt.Printf("Error encountered downloading from %s: %s; continuing", request, err)
-		} else {
 			time.Sleep(retrySleepSeconds * time.Second) // Effective linear backoff
 		}
   }

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 		cli.IntFlag{
 			Name:  optionRetryNumber,
 			Value: 0,
-			Usage: "The number of retries fetch will attempt to make to retrieve the target. 0, the default, means no retries.",
+			Usage: "The number of retries fetch will attempt to make to retrieve the target in the case of transient errors (e.g. timeouts). 0, the default, means no retries.",
 		},
 		cli.BoolFlag{
 			Name:  optionWithProgress,


### PR DESCRIPTION
Wrap http requests in a retry loop. Nothing sophisticated, just sleep() based linear backoff.