### PR TITLE
Delete circleci nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,16 +57,3 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-
-
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only: master
-    jobs:
-      - test:
-          context:
-            - Gruntwork Admin


### PR DESCRIPTION
We've decided to delete all "nightly" or triggered jobs as they are incompatible with circleci contexts.