### PR TITLE
fixes issues 26 & 46. Added support for pagination

### DIFF
--- a/github.go
+++ b/github.go
@@ -208,6 +208,7 @@ func createGitHubRepoUrlForPath(repo GitHubRepo, path string) string {
 }
 
 // Get the Next paginated path from the link url api.github.com/repos/:owner/:repo/:path
+// If there is no next page, return an empty string
 // Links are formatted: "<url>; rel=next, <url>; rel=last"
 func getNextPath(links string) string {
 	if len(links) == 0 {

--- a/github_test.go
+++ b/github_test.go
@@ -57,6 +57,33 @@ func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 	}
 }
 
+func TestGetNextPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		links            string
+		expectedNextPath string
+	}{
+		{`<https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15>; rel="next", <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last"`, "code?q=addClass+user%3Amozilla&page=15"},
+		{`<https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15>; rel="first", <https://api.github.com/search/code?q=addClass+user%3Amozilla&page=34>; rel="last"`, ""},
+		{`<https://api.github.com/temp/proj/tags?page=15>; rel="next", <https://api.github.com/temp/proj/tags?page=15>; rel="last"`, "tags?page=15"},
+		{`<https://api.github.com/temp/proj/tags?per_page=100&page=15>;  	rel="next", <https://api.github.com/temp/proj/tags?per_page=100&page=15>;  rel="last"`, "tags?per_page=100&page=15"},
+	}
+
+	for _, tc := range cases {
+		nextPath, err := getNextPath(tc.links)
+
+		if err != nil {
+			t.Fatalf("error getting next path: %s", err)
+		}
+
+		if nextPath != tc.expectedNextPath {
+			t.Fatalf("Expected next path %s, but got %s", tc.expectedNextPath, nextPath)
+		}
+	}
+
+}
+
 func TestParseUrlIntoGithubInstance(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`FetchTags` only returns the first 30 tags so 

`fetch  --repo https://github.com/gruntwork-io/terratest --tag="<0.2.0"  ./LocalDir`

fails with ` ... Tag does not exist` because terratest has 200+ tags and 0.2.0 isn't in the first 30 tags. 

I increased the `per_page` result to 100 and added a loop to get the next link from the [link header](https://docs.github.com/en/free-pro-team@latest/rest/guides/traversing-with-pagination). 

I believe this fixes both issue #26 and #46. 