### PR TITLE
Pete/87/broken branch

### DIFF
--- a/file.go
+++ b/file.go
@@ -151,6 +151,9 @@ func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, ins
 
 	// This represents either a commit, branch, or git tag
 	var gitRef string
+	// Ordering matters in this conditional
+	// GitRef needs to be the fallback and therefore must be last
+	// See https://github.com/gruntwork-io/fetch/issues/87 for an example
 	if gitHubCommit.CommitSha != "" {
 		gitRef = gitHubCommit.CommitSha
 	} else if gitHubCommit.BranchName != "" {

--- a/file.go
+++ b/file.go
@@ -151,14 +151,14 @@ func MakeGitHubZipFileRequest(gitHubCommit GitHubCommit, gitHubToken string, ins
 
 	// This represents either a commit, branch, or git tag
 	var gitRef string
-	if gitHubCommit.GitRef != "" {
-		gitRef = gitHubCommit.GitRef
-	} else if gitHubCommit.CommitSha != "" {
+	if gitHubCommit.CommitSha != "" {
 		gitRef = gitHubCommit.CommitSha
 	} else if gitHubCommit.BranchName != "" {
 		gitRef = gitHubCommit.BranchName
 	} else if gitHubCommit.GitTag != "" {
 		gitRef = gitHubCommit.GitTag
+	} else if gitHubCommit.GitRef != "" {
+		gitRef = gitHubCommit.GitRef
 	} else {
 		return request, fmt.Errorf("Neither a GitCommitSha nor a GitTag nor a BranchName were specified so impossible to identify a specific commit to download.")
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	cli "gopkg.in/urfave/cli.v1"
+)
+
+func TestFetchWithBranchOption(t *testing.T) {
+	t.Parallel()
+
+	tmpDownloadPath := createTempDir(t, "fetch-branch-test")
+
+	cases := []struct {
+		name       string
+		repoUrl    string
+		branchName string
+		sourcePath string
+	}{
+		// Test on a public repo whose sole purpose is to be a test fixture for this tool
+		{"branch option with public repo", "https://github.com/gruntwork-io/fetch-test-public", "sample-branch", "/"},
+
+		// Private repo equivalent
+		{"branch option with private repo", "https://github.com/gruntwork-io/fetch-test-private", "sample-branch", "/"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := fmt.Sprintf("fetch --repo %s --branch %s --source-path %s %s", tc.repoUrl, tc.branchName, tc.sourcePath, tmpDownloadPath)
+			//t.Fatal(cmd)
+			output, _, err := runFetchCommandWithOutput(t, cmd)
+			require.NoError(t, err)
+
+			// When --branch is specified, ensure the latest commit is fetched
+			assert.Contains(t, output, "Downloading latest commit from branch")
+		})
+	}
+}
+
+func runFetchCommandWithOutput(t *testing.T, command string) (string, string, error) {
+	// Note: As most of fetch writes directly to stdout and stderr using the fmt package, we need to temporarily override
+	// the OS pipes. This is based loosely on https://stackoverflow.com/questions/10473800/in-go-how-do-i-capture-stdout-of-a-function-into-a-string/10476304#10476304
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	stdoutReader, stdoutWriter, err1 := os.Pipe()
+	if err1 != nil {
+		return "", "", err1
+	}
+
+	stderrReader, stderrWriter, err2 := os.Pipe()
+	if err2 != nil {
+		return "", "", err2
+	}
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+
+	// override the pipes to capture output
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+
+	// execute the fetch command which produces output
+	err := runFetchCommand(t, command)
+	if err != nil {
+		return "", "", err
+	}
+
+	// copy the output to the buffers in seperate goroutines so printing can't block indefinitely
+	stdoutC := make(chan bytes.Buffer)
+	stderrC := make(chan bytes.Buffer)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, stdoutReader)
+		stdoutC <- buf
+	}()
+
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, stderrReader)
+		stderrC <- buf
+	}()
+
+	// reset the pipes back to normal
+	stdoutWriter.Close()
+	stderrWriter.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	stdout = <-stdoutC
+	stderr = <-stderrC
+
+	// log the buffers for easier debugging. this is inspired by the integration tests in Terragrunt.
+	// For more information, see: https://github.com/gruntwork-io/terragrunt/blob/master/test/integration_test.go.
+	logBufferContentsLineByLine(t, stdout, "stdout")
+	logBufferContentsLineByLine(t, stderr, "stderr")
+	return stdout.String(), stderr.String(), nil
+}
+
+func runFetchCommand(t *testing.T, command string) error {
+	args := strings.Split(command, " ")
+
+	app := CreateFetchCli(VERSION)
+	app.Action = runFetchWrapper
+	return app.Run(args)
+}
+
+func logBufferContentsLineByLine(t *testing.T, out bytes.Buffer, label string) {
+	t.Logf("[%s] Full contents of %s:", t.Name(), label)
+	lines := strings.Split(out.String(), "\n")
+	for _, line := range lines {
+		t.Logf("[%s] %s", t.Name(), line)
+	}
+}
+
+func createTempDir(t *testing.T, prefix string) string {
+	dir, err := ioutil.TempDir(os.TempDir(), prefix)
+	if err != nil {
+		t.Fatalf("Could not create temporary directory due to error: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	return dir
+}
+
+// We want to call runFetch() using the app.Action wrapper like the main CLI handler, but we don't want to write to strerr
+// and suddenly exit using os.Exit(1), so we use a separate wrapper method in the integration tests.
+func runFetchTestWrapper(c *cli.Context) error {
+	return runFetch(c)
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,34 +15,40 @@ import (
 )
 
 func TestFetchWithBranchOption(t *testing.T) {
-	t.Parallel()
+	// Note: we don't run these tests in parallel as runFetchCommandWithOutput currently overrides the
+	// stdout and stderr variables which may result in unstable tests.
 
 	tmpDownloadPath := createTempDir(t, "fetch-branch-test")
 
 	cases := []struct {
-		name       string
-		repoUrl    string
-		branchName string
-		sourcePath string
+		name         string
+		repoUrl      string
+		branchName   string
+		sourcePath   string
+		expectedFile string
 	}{
 		// Test on a public repo whose sole purpose is to be a test fixture for this tool
-		{"branch option with public repo", "https://github.com/gruntwork-io/fetch-test-public", "sample-branch", "/"},
+		{"branch option with public repo", "https://github.com/gruntwork-io/fetch-test-public", "sample-branch", "/", "foo.txt"},
 
 		// Private repo equivalent
-		{"branch option with private repo", "https://github.com/gruntwork-io/fetch-test-private", "sample-branch", "/"},
+		{"branch option with private repo", "https://github.com/gruntwork-io/fetch-test-private", "sample-branch", "/", "bar.txt"},
 	}
 
 	for _, tc := range cases {
+		// The following is necessary to make sure tc's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := fmt.Sprintf("fetch --repo %s --branch %s --source-path %s %s", tc.repoUrl, tc.branchName, tc.sourcePath, tmpDownloadPath)
-			//t.Fatal(cmd)
 			output, _, err := runFetchCommandWithOutput(t, cmd)
 			require.NoError(t, err)
 
 			// When --branch is specified, ensure the latest commit is fetched
 			assert.Contains(t, output, "Downloading latest commit from branch")
+
+			// Ensure the expected file was downloaded
+			assert.FileExists(t, JoinPath(tmpDownloadPath, tc.expectedFile))
 		})
 	}
 }
@@ -50,6 +56,7 @@ func TestFetchWithBranchOption(t *testing.T) {
 func runFetchCommandWithOutput(t *testing.T, command string) (string, string, error) {
 	// Note: As most of fetch writes directly to stdout and stderr using the fmt package, we need to temporarily override
 	// the OS pipes. This is based loosely on https://stackoverflow.com/questions/10473800/in-go-how-do-i-capture-stdout-of-a-function-into-a-string/10476304#10476304
+	// Our goal eventually is to remove this, but we'll need to introduce a logger as mentioned in: https://github.com/gruntwork-io/fetch/issues/89
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}
 
@@ -76,7 +83,7 @@ func runFetchCommandWithOutput(t *testing.T, command string) (string, string, er
 		return "", "", err
 	}
 
-	// copy the output to the buffers in seperate goroutines so printing can't block indefinitely
+	// copy the output to the buffers in separate goroutines so printing can't block indefinitely
 	stdoutC := make(chan bytes.Buffer)
 	stderrC := make(chan bytes.Buffer)
 	go func() {

--- a/main.go
+++ b/main.go
@@ -52,12 +52,19 @@ const optionWithProgress = "progress"
 
 const envVarGithubToken = "GITHUB_OAUTH_TOKEN"
 
-func main() {
+// Create the Fetch CLI App
+func CreateFetchCli(version string) *cli.App {
+	cli.OsExiter = func(exitCode int) {
+		// Do nothing. We just need to override this function, as the default value calls os.Exit, which
+		// kills the app (or any automated test) dead in its tracks.
+	}
+
 	app := cli.NewApp()
 	app.Name = "fetch"
 	app.Usage = "fetch makes it easy to download files, folders, and release assets from a specific git commit, branch, or tag of public and private GitHub repos."
 	app.UsageText = "fetch [global options] <local-download-path>\n   (See https://github.com/gruntwork-io/fetch for examples, argument definitions, and additional docs.)"
-	app.Version = VERSION
+	app.Author = "Gruntwork <www.gruntwork.io>"
+	app.Version = version
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -112,6 +119,11 @@ func main() {
 		},
 	}
 
+	return app
+}
+
+func main() {
+	app := CreateFetchCli(VERSION)
 	app.Action = runFetchWrapper
 
 	// Run the definition of App.Action

--- a/main.go
+++ b/main.go
@@ -302,6 +302,9 @@ func downloadSourcePaths(sourcePaths []string, destPath string, githubRepo GitHu
 
 	// Download that release as a .zip file
 
+	// Ordering matters in this conditional
+	// GitRef needs to be the fallback and therefore must be last
+	// See https://github.com/gruntwork-io/fetch/issues/87 for an example
 	if gitHubCommit.CommitSha != "" {
 		fmt.Printf("Downloading git commit \"%s\" of %s ...\n", gitHubCommit.CommitSha, githubRepo.Url)
 	} else if gitHubCommit.BranchName != "" {

--- a/main.go
+++ b/main.go
@@ -290,14 +290,14 @@ func downloadSourcePaths(sourcePaths []string, destPath string, githubRepo GitHu
 
 	// Download that release as a .zip file
 
-	if gitHubCommit.GitRef != "" {
-		fmt.Printf("Downloading git reference \"%s\" of %s ...\n", gitHubCommit.GitRef, githubRepo.Url)
-	} else if gitHubCommit.CommitSha != "" {
+	if gitHubCommit.CommitSha != "" {
 		fmt.Printf("Downloading git commit \"%s\" of %s ...\n", gitHubCommit.CommitSha, githubRepo.Url)
 	} else if gitHubCommit.BranchName != "" {
 		fmt.Printf("Downloading latest commit from branch \"%s\" of %s ...\n", gitHubCommit.BranchName, githubRepo.Url)
 	} else if gitHubCommit.GitTag != "" {
 		fmt.Printf("Downloading tag \"%s\" of %s ...\n", latestTag, githubRepo.Url)
+	} else if gitHubCommit.GitRef != "" {
+		fmt.Printf("Downloading git reference \"%s\" of %s ...\n", gitHubCommit.GitRef, githubRepo.Url)
 	} else {
 		return fmt.Errorf("The commit sha, tag, and branch name are all empty.")
 	}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,10 @@
+package main
+
+import "path/filepath"
+
+// Windows systems use \ as the path separator *nix uses /
+// Use this function when joining paths to force the returned path to use / as the path separator
+// This will improve cross-platform compatibility
+func JoinPath(elem ...string) string {
+	return filepath.ToSlash(filepath.Join(elem...))
+}


### PR DESCRIPTION
This closes #87.

This has no additional tests yet.

We don't have specific tests for `MakeGitHubZipFileRequest`, which I modified to put the conditional for GitRef last.

We do test `downloadGithubZipFile` which calls `MakeGitHubZipFileRequest`, and it seems like our test `TestDownloadGitBranchZipFile` would be designed to catch this. Here's the logic that I unwrapped for this particular case:

```
since options.GitRef is not specified
    code detects a tag with a tag constraint

since there is no specific release that matches the version constraint
    latestTag is set to the latest release it can find
    desiredTag is set to latestTag

desiredTag is passed into downloadSourcePaths as latestTag

in func downloadSourcePaths
    GitRef and GitTag are both set to latestTag
    BranchName will exist, as well
    but this is where ordering is important
    GitRef needs to be checked last, otherwise downloading a branch cannot work
```

I'm open to suggestions on improving testing here, it seems like `downloadGithubZipFile` would need to be tested with multiple things set to make sure it does the right action, but I'm not positive.

Here's the evidence of this fixing the problem @brikis98 encountered. I also ran all of the tests, and they're passing.

```
# Test with --branch
 fetch git:(pete/87/broken_branch) $ ./fetch --repo="https://github.com/gruntwork-io/terraform-google-ci" --branch="gcp-helpers" --source-path="/modules/gcp-helpers" "/tmp/download-dir/gcp-helpers"
Downloading latest commit from branch "gcp-helpers" of https://github.com/gruntwork-io/terraform-google-ci ...
Extracting files from <repo>/modules/gcp-helpers to /tmp/download-dir/gcp-helpers ... 3 files extracted
Download and file extraction complete.

# Test with --ref
 fetch git:(pete/87/broken_branch) $ ./fetch --repo="https://github.com/gruntwork-io/terraform-google-ci" --ref="gcp-helpers" --source-path="/modules/gcp-helpers" "/tmp/download-dir/gcp-helpers"
Downloading tag "gcp-helpers" of https://github.com/gruntwork-io/terraform-google-ci ...
Extracting files from <repo>/modules/gcp-helpers to /tmp/download-dir/gcp-helpers ... 3 files extracted
Download and file extraction complete.

# Testing TestDownloadGitBranchZipFile (which wasn't broken before, either)
 fetch git:(pete/87/broken_branch) $ go test -v -run TestDownloadGitBranchZipFile
=== RUN   TestDownloadGitBranchZipFile
=== PAUSE TestDownloadGitBranchZipFile
=== CONT  TestDownloadGitBranchZipFile
--- PASS: TestDownloadGitBranchZipFile (1.37s)
PASS
ok  	github.com/gruntwork-io/fetch	1.529s
```