### PR TITLE
Document the precedence of --ref properly

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func CreateFetchCli(version string) *cli.App {
 		},
 		cli.StringFlag{
 			Name:  optionRef,
-			Usage: "The git reference to download. If specified, will override --commit, --branch, and --tag.",
+			Usage: "The git reference to download. If specified, will take lower precendence than --commit, --branch, and --tag.",
 		},
 		cli.StringFlag{
 			Name:  optionCommit,


### PR DESCRIPTION
`--ref` takes lower precedence than the other flags.

This documentation change reflects reality.