### PR TITLE
Update CircleCi base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.13
+    - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.16-go111module
 
 version: 2
 jobs:


### PR DESCRIPTION
Update to the latest base image, which has a newer version of Go, and a newer version of our `build-go-binaries` script. This supports building fetch for Darwin/ARM, which hopefully fixes #82.