### PR TITLE
Perform direct asset name comparison

### DIFF
--- a/github_test.go
+++ b/github_test.go
@@ -25,7 +25,7 @@ func TestGetListOfReleasesFromGitHubRepo(t *testing.T) {
 		testInst         GitHubInstance
 	}{
 		// Test on a public repo whose sole purpose is to be a test fixture for this tool
-		{"https://github.com/gruntwork-io/fetch-test-public", "v0.0.1", "v0.0.3", 3, "", testInst},
+		{"https://github.com/gruntwork-io/fetch-test-public", "v0.0.1", "v0.0.4", 4, "", testInst},
 
 		// Private repo equivalent
 		{"https://github.com/gruntwork-io/fetch-test-private", "v0.0.2", "v0.0.2", 1, os.Getenv("GITHUB_OAUTH_TOKEN"), testInst},

--- a/main.go
+++ b/main.go
@@ -455,6 +455,11 @@ func findAssetsInRelease(assetRegex string, release GitHubReleaseApiResponse) ([
 		if matched {
 			assetRef := asset
 			matches = append(matches, &assetRef)
+		} else if asset.Name == assetRegex {
+			// Sometimes the actual asset name contains regex symbols that could mess up matching.
+			// Perform a direct comparison as a last resort.
+			assetRef := asset
+			matches = append(matches, &assetRef)
 		}
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -52,7 +52,7 @@ func TestDownloadReleaseAssetsWithRegexCharacters(t *testing.T) {
 
 	const githubRepoUrl = "https://github.com/gruntwork-io/fetch-test-public"
 	const releaseAsset = "hello+world.txt"
-	const assetVersion = "v0.0.4"
+	const assetVersion = "v0.0.3"
 
 	githubRepo, err := ParseUrlIntoGitHubRepo(githubRepoUrl, "", testInst)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -42,6 +42,41 @@ func TestDownloadReleaseAssets(t *testing.T) {
 	}
 }
 
+func TestDownloadReleaseAssetsWithRegexCharacters(t *testing.T) {
+	tmpDir := mkTempDir(t)
+	logger := GetProjectLogger()
+	testInst := GitHubInstance{
+		BaseUrl: "github.com",
+		ApiUrl:  "api.github.com",
+	}
+
+	const githubRepoUrl = "https://github.com/gruntwork-io/fetch-test-public"
+	const releaseAsset = "hello+world.txt"
+	const assetVersion = "v0.0.4"
+
+	githubRepo, err := ParseUrlIntoGitHubRepo(githubRepoUrl, "", testInst)
+	if err != nil {
+		t.Fatalf("Failed to parse sample release asset GitHub URL into Fetch GitHubRepo struct: %s", err)
+	}
+
+	assetPaths, fetchErr := downloadReleaseAssets(logger, releaseAsset, tmpDir, githubRepo, assetVersion, false)
+	if fetchErr != nil {
+		t.Fatalf("Failed to download release asset: %s", fetchErr)
+	}
+
+	if len(assetPaths) != 1 {
+		t.Fatalf("Expected to download 1 assets, not %d", len(assetPaths))
+	}
+
+	assetPath := assetPaths[0]
+
+	if _, err := os.Stat(assetPath); os.IsNotExist(err) {
+		t.Fatalf("Downloaded file should exist at %s", assetPath)
+	} else {
+		fmt.Printf("Verified the downloaded asset exists at %s\n", assetPath)
+	}
+}
+
 func TestInvalidReleaseAssetsRegex(t *testing.T) {
 	tmpDir := mkTempDir(t)
 	logger := GetProjectLogger()

--- a/main_test.go
+++ b/main_test.go
@@ -52,7 +52,7 @@ func TestDownloadReleaseAssetsWithRegexCharacters(t *testing.T) {
 
 	const githubRepoUrl = "https://github.com/gruntwork-io/fetch-test-public"
 	const releaseAsset = "hello+world.txt"
-	const assetVersion = "v0.0.3"
+	const assetVersion = "v0.0.4"
 
 	githubRepo, err := ParseUrlIntoGitHubRepo(githubRepoUrl, "", testInst)
 	if err != nil {


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

Handle situations where the release asset name contains regex symbols that could mess up matching.

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

Fixes #93 
