### PR TITLE
Output release asset contents to standard output

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -52,6 +52,43 @@ func TestFetchWithBranchOption(t *testing.T) {
 	}
 }
 
+func TestFetchWithStdoutOption(t *testing.T) {
+	tmpDownloadPath, err := ioutil.TempDir("", "fetch-stdout-test")
+	require.NoError(t, err)
+
+	repoUrl := "https://github.com/gruntwork-io/fetch-test-public"
+	releaseTag := "v0.0.4"
+	releaseAsset := "hello+world.txt"
+
+	cmd := fmt.Sprintf("fetch --repo %s --tag %s --release-asset %s --stdout true %s", repoUrl, releaseTag, releaseAsset, tmpDownloadPath)
+	t.Logf("Testing command: %s", cmd)
+	stdoutput, _, err := runFetchCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	// Ensure the expected file was downloaded
+	assert.FileExists(t, JoinPath(tmpDownloadPath, releaseAsset))
+
+	// When --stdout is specified, ensure the file contents are piped to the standard output stream
+	assert.Contains(t, stdoutput, "hello world")
+}
+
+func TestFetchWithStdoutOptionMultipleAssets(t *testing.T) {
+	tmpDownloadPath, err := ioutil.TempDir("", "fetch-stdout-test")
+	require.NoError(t, err)
+
+	repoUrl := SAMPLE_RELEASE_ASSET_GITHUB_REPO_URL
+	releaseTag := SAMPLE_RELEASE_ASSET_VERSION
+	releaseAsset := SAMPLE_RELEASE_ASSET_REGEX
+
+	cmd := fmt.Sprintf("fetch --repo %s --tag %s --release-asset %s --stdout true %s", repoUrl, releaseTag, releaseAsset, tmpDownloadPath)
+	t.Logf("Testing command: %s", cmd)
+	_, stderr, err := runFetchCommandWithOutput(t, cmd)
+	require.NoError(t, err)
+
+	// When --stdout is specified, ensure the file contents are piped to the standard output stream
+	assert.Contains(t, stderr, "Multiple assets were downloaded. Ignoring --stdout")
+}
+
 func runFetchCommandWithOutput(t *testing.T, command string) (string, string, error) {
 	stdout := bytes.Buffer{}
 	stderr := bytes.Buffer{}

--- a/main.go
+++ b/main.go
@@ -263,7 +263,7 @@ func runFetch(c *cli.Context, logger *logrus.Logger) error {
 			if err != nil {
 				return err
 			}
-			os.Stdout.Write(dat)
+			c.App.Writer.Write(dat) // This should be stdout
 		} else {
 
 			if len(assetPaths) > 1 {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type FetchOptions struct {
 	ReleaseAsset             string
 	ReleaseAssetChecksums    map[string]bool
 	ReleaseAssetChecksumAlgo string
+	Stdout                   bool
 	LocalDownloadPath        string
 	GithubApiVersion         string
 	WithProgress             bool
@@ -53,6 +54,7 @@ const optionSourcePath = "source-path"
 const optionReleaseAsset = "release-asset"
 const optionReleaseAssetChecksum = "release-asset-checksum"
 const optionReleaseAssetChecksumAlgo = "release-asset-checksum-algo"
+const optionStdout = "stdout"
 const optionGithubAPIVersion = "github-api-version"
 const optionWithProgress = "progress"
 const optionLogLevel = "log-level"
@@ -116,6 +118,10 @@ func CreateFetchCli(version string, writer io.Writer, errwriter io.Writer) *cli.
 		cli.StringFlag{
 			Name:  optionReleaseAssetChecksumAlgo,
 			Usage: "The algorithm Fetch will use to compute a checksum of the release asset. Acceptable values\n\tare \"sha256\" and \"sha512\".",
+		},
+		cli.StringFlag{
+			Name:  optionStdout,
+			Usage: "If \"true\", the contents of the release asset is sent to standard output so it can be piped to another command.",
 		},
 		cli.StringFlag{
 			Name:  optionGithubAPIVersion,
@@ -250,6 +256,19 @@ func runFetch(c *cli.Context, logger *logrus.Logger) error {
 		}
 	}
 
+	if options.Stdout {
+		// Print to stdout only if a single asset was downloaded
+		if len(assetPaths) == 1 {
+			dat, err := os.ReadFile(assetPaths[0])
+			if err != nil {
+				return err
+			}
+			os.Stdout.Write(dat)
+		} else {
+			logger.Warn("Multiple assets were downloaded. Ignoring --stdout")
+		}
+	}
+
 	return nil
 }
 
@@ -282,6 +301,7 @@ func parseOptions(c *cli.Context, logger *logrus.Logger) FetchOptions {
 		ReleaseAsset:             c.String(optionReleaseAsset),
 		ReleaseAssetChecksums:    assetChecksumMap,
 		ReleaseAssetChecksumAlgo: c.String(optionReleaseAssetChecksumAlgo),
+		Stdout:                   c.String(optionStdout) == "true",
 		LocalDownloadPath:        localDownloadPath,
 		GithubApiVersion:         c.String(optionGithubAPIVersion),
 		WithProgress:             c.IsSet(optionWithProgress),

--- a/main.go
+++ b/main.go
@@ -265,7 +265,13 @@ func runFetch(c *cli.Context, logger *logrus.Logger) error {
 			}
 			os.Stdout.Write(dat)
 		} else {
-			logger.Warn("Multiple assets were downloaded. Ignoring --stdout")
+
+			if len(assetPaths) > 1 {
+				logger.Warn("Multiple assets were downloaded. Ignoring --stdout")
+			} else {
+				logger.Warn("No assets were downloaded. Ignoring --stdout")
+			}
+
 		}
 	}
 


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

An initial stab at supporting sending the contents of a downloaded asset to standard output

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

Addresses #101 
